### PR TITLE
Hsc(v3) tap service demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ These notebooks are also under continuous integration<sup>\*</sup> to ensure tha
     - [TESS API Demo](MAST/TESS/tess_api_demo.ipynb)
     - [TESS TIC API Demo (no astroquery)](MAST/TESS/tess_tic_api_demo.ipynb)
     - [TESS TIC Search for Dwarf Stars Around HD 209458](MAST/TESS/tess_tic_search_for_dwarf_stars_around_hd_209458.ipynb)
+  - Hubble Source Catalog
+    - [TAP HSC Functionality Demo] (MAST/HSC/TAP HSC functionality demo.ipynb)
 - HST
   - ACS
   - COS


### PR DESCRIPTION
This notebook represents a demo of the Hubble Source Catalog (most recent, version 3) Table Access Protocol service at MAST, using the astroquery TapPlus client. Myself and Rick White originally put together this notebook, which was published in the MAST newsletter announcing the service (https://archive.stsci.edu/archive_news/2018/05-May/index.html). Rick added existing HSC use cases and documentation links for them. I've reorganized the imports and cells slightly and added documentation to match the style guides to the best of my knowledge, but the basic content examples remain the same. 