### PR TITLE
Updated convert script for changed arg

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import subprocess
 
 from nbpages import make_parser, run_parsed, make_html_index
 
@@ -9,7 +10,23 @@ args = make_parser().parse_args()
 if args.template_file is None and os.path.exists('nb_html.tpl'):
     args.template_file = 'nb_html.tpl'
 
-if args.exclude is None:
+if args.changed:
+    # If changed option is set, only convert notebooks that where changed.
+    # This command will list all changed files on current commit from master.
+    list_changed_files_cmd = "git show --pretty=format: --name-only -r master"
+
+    # Get list of changed files using git
+    # git must be installed and accessible from the calling shell
+    changed_files = subprocess.check_output(list_changed_files_cmd,
+                                                shell=True).decode()
+    # Only get changed noteobook files, strip path from their name
+    to_include = [os.path.split(x)[1].replace('.ipynb', '')
+            for x in changed_files.strip().split('\n') if ".ipynb" in x]
+
+    if to_include:
+        args.include = ",".join(to_include)
+
+if args.exclude is None and args.changed is None:
     # If there is an "exclude_notebooks" file, use that to find which ones to
     # skip.  Format is one pattern per line, "#" for comments.
     # note that this will be ignored if exclude is given at the command line.


### PR DESCRIPTION
This addition allows the convert script to only execute/convert notebooks that were changed/added in the current commit. Requires [nbpages PR#: 6](https://github.com/eteq/nbpages/pull/6). Calling the convert script with `python convert.py --changed`signals the script to only check/execute notebooks that were changed on the current git commit from the master branch.

This should be implemented in the CI config, for example:
```
if pull_request:
    python convert.py --changed
else:
    python convert.py
```

This would dramatically save build minutes for CI pull requests, only converting new/changed notebooks.