### PR TITLE
Removed fallback cache for environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-env-{{ checksum "environment.yml" }}
-            - v1-env-
 
       - run:
           name: Setup Environment


### PR DESCRIPTION
Fallback cache caused circleci to used cache environment even if changes were made to environment.yml. Removed fallback key, any changes to environment.yml will now cause circleci to create new conda environment.

Fixes [Issue 79](https://github.com/spacetelescope/notebooks/issues/79)