### PR TITLE
Suppress CRDS - Info messages in DrizzlePac Notebooks

### DIFF
--- a/notebooks/DrizzlePac/Initialization/Initialization.ipynb
+++ b/notebooks/DrizzlePac/Initialization/Initialization.ipynb
@@ -218,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subprocess.check_output('crds bestrefs --files ib2j02n5q_flc.fits --sync-references=1 --update-bestrefs', shell=True)"
+    "subprocess.check_output('crds bestrefs --files ib2j02n5q_flc.fits --sync-references=1 --update-bestrefs', shell=True, stderr=subprocess.DEVNULL)"
    ]
   },
   {

--- a/notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
+++ b/notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
@@ -119,7 +119,7 @@
     "os.environ['CRDS_SERVER_URL'] = 'https://hst-crds.stsci.edu'\n",
     "os.environ['CRDS_PATH'] = os.path.abspath(os.path.join('.', 'reference_files'))\n",
     "\n",
-    "subprocess.check_output('crds bestrefs --files ua0605*_c0m.fits --sync-references=1 --update-bestrefs', shell=True)\n",
+    "subprocess.check_output('crds bestrefs --files ua0605*_c0m.fits --sync-references=1 --update-bestrefs', shell=True, stderr=subprocess.DEVNULL)\n",
     "\n",
     "os.environ['uref'] = os.path.abspath(os.path.join('.', 'reference_files', 'references', 'hst', 'wfpc2')) + os.path.sep"
    ]


### PR DESCRIPTION
Added stderr=subprocess.DEVNULL to subprocess calls to suppress CRDS - INFO messages from CI logs, closes [Issue 43](https://github.com/spacetelescope/notebooks/issues/43).

Example:
```
  subprocess.check_output('crds bestrefs --files ua0605*_c0m.fits --sync-references=1 --update-bestrefs', shell=True, stderr=subprocess.DEVNULL)
```

Needs review and approval from Drizzlepac notebooks author.