### PR TITLE
Increased convert step no-output timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
             source activate notebooks_env
             conda info --envs
             python ./convert.py
+          no_output_timeout: 20m
 
       - run:
           name: Check notebooks


### PR DESCRIPTION
Several previous PR builds have timed out on the convert step, I believe some async network calls were taking longer than normal and caused this to not be seen in testing. Increasing the timeout to a reasonable time should prevent this. Should be adjusted as we have more tests ran.

EDIT: Fix #87 