### PR TITLE
Junit Test Reports in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,12 @@ jobs:
             conda info --envs
             source activate notebooks_env
             conda info --envs
-            python ./convert.py
+            mkdir test-results
+            python ./convert.py --report test-results/results.xml
           no_output_timeout: 20m
+
+      - store_test_results:
+          path: test-results
 
       - run:
           name: Check notebooks

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: notebooks_env
 
 channels:
   - astropy
-  - astropy-ci-extras
   - http://ssb.stsci.edu/astroconda
   - defaults
 
@@ -26,4 +25,5 @@ dependencies:
 
   - pip:
     - k2flix
+    - junit_xml
     - git+https://github.com/eteq/nbpages.git


### PR DESCRIPTION
Updated circle config to use newly added feature of test reports in nbpages. This also continues the build even if a notebook fails and simply logs the failed notebook.

Also removed an obsolete channel in the environment file, this will generate a new environment which is needed to pull in the new version of nbpages.

Closes #83 