### PR TITLE
[Ready] Fix for include arg

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -9,10 +9,10 @@ args = make_parser().parse_args()
 if args.template_file is None and os.path.exists('nb_html.tpl'):
     args.template_file = 'nb_html.tpl'
 
-if args.exclude is None:
+if args.exclude is None and args.include is None:
     # If there is an "exclude_notebooks" file, use that to find which ones to
     # skip.  Format is one pattern per line, "#" for comments.
-    # note that this will be ignored if exclude is given at the command line.
+    # Note that this will be ignored if exclude or include is given at the command line.
     to_exclude = []
     if os.path.isfile('exclude_notebooks'):
         with open('exclude_notebooks') as f:


### PR DESCRIPTION
This fixes an issue when the `--include` arg is set from the command line and an `exclude_notebook` file is present.

Closes #98 