### PR TITLE
MAST: Adding TASC light curve notebook

### DIFF
--- a/notebooks/MAST/TESS/interm_tasc_lc/interm_tasc_lc.ipynb
+++ b/notebooks/MAST/TESS/interm_tasc_lc/interm_tasc_lc.ipynb
@@ -7,7 +7,7 @@
     "<a id=\"title_ID\"></a>\n",
     "# Intermediate: Finding Flares and Variable Stars in TASC Light Curves\n",
     "\n",
-    "This notebook demostrates MAST's programmatic tools for accessing TESS time series data while exploring a flaring star from the literature and a nearby variable star.  \n",
+    "This notebook demostrates MAST's programmatic tools for accessing TESS time series data while exploring a flaring star from the literature ([G&uuml;nther et al 2019](https://arxiv.org/abs/1901.00443)) and a nearby variable star.  \n",
     "\n",
     "The following topics will be covered:\n",
     "- Using the MAST API to get mission pipeline and TASOC light curves\n",
@@ -15,7 +15,8 @@
     "- Using the MAST API to make an full frame image (FFI) cutout\n",
     "- Creating a movie of TPF frames in Python\n",
     "- Using the MAST API to get a list of TESS Input Catalog (TIC) sources\n",
-    "- Over plotting TIC sources on TESS images"
+    "- Over plotting TIC sources on TESS images\n",
+    "- Exploring the period of a variable star"
    ]
   },
   {
@@ -230,7 +231,7 @@
    "source": [
     "#### Downloading files\n",
     "\n",
-    "We can choose do download some or all of the associated data files, in this case since we just have the two light curves, we will download all of the products."
+    "We can choose to download some or all of the associated data files, in this case since we just have the two light curves, we will download all of the products."
    ]
   },
   {
@@ -696,7 +697,7 @@
    "outputs": [],
    "source": [
     "lomb = LombScargle(variable_lc[\"TIME\"], variable_lc[\"FLUX_RAW\"])\n",
-    "frequency, power = lomb.autopower()"
+    "frequency, power = lomb.autopower(maximum_frequency=25)"
    ]
   },
   {
@@ -712,13 +713,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bfig = plotting.figure(plot_width=850, plot_height=300, x_axis_type=\"log\", x_range=(0.008, 1),\n",
+    "bfig = plotting.figure(plot_width=850, plot_height=300, x_range=(0,25),\n",
     "                       title=f\"Periodogram (TIC{variable_tic_id})\")\n",
     "\n",
-    "bfig.line(1/frequency, power, line_color='black')\n",
+    "bfig.line(frequency, power, line_color='black')\n",
     "\n",
     "# Labeling the axes\n",
-    "bfig.xaxis.axis_label = \"Period\"\n",
+    "bfig.xaxis.axis_label = \"Frequency (1/day)\"\n",
     "bfig.yaxis.axis_label = \"Power\"\n",
     "\n",
     "plotting.show(bfig)"
@@ -728,9 +729,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Phasing on the highest power period\n",
+    "#### Phasing on the highest power period/frequency\n",
     "\n",
-    "We will pick out the highest powered period in the abover periodogram and phase the stellar light curve on that period."
+    "There is a clear dominant frequency in the above plot, with a small harmonic also visible. We will phase the stellar light curve on the period corresponding to the dominant frequency and plot both it and the corresponding sinusoidal fit."
    ]
   },
   {
@@ -739,8 +740,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "period = 1/frequency[np.argmax(power)].value\n",
-    "period"
+    "dominant_freq = frequency[np.argmax(power)].value\n",
+    "print(f\"The dominant priod: {1/dominant_freq*24:.3} hours\")"
    ]
   },
   {
@@ -752,11 +753,11 @@
     "bfig = plotting.figure(plot_width=850, plot_height=300, title=f\"Phased Lightcurve (TIC{variable_tic_id})\")\n",
     "\n",
     "# Plotting the phased light curve\n",
-    "bfig.circle(variable_lc[\"TIME\"]%period,variable_lc[\"FLUX_RAW\"], fill_color=\"black\",size=4, line_color=None)\n",
+    "bfig.circle(variable_lc[\"TIME\"]%(1/dominant_freq),variable_lc[\"FLUX_RAW\"], fill_color=\"black\",size=4, line_color=None)\n",
     "\n",
     "# Plotting the periodic fit\n",
-    "t_fit = np.linspace(0,period,100)\n",
-    "bfig.line(t_fit, lomb.model(t_fit, 1/period), color='#1b9f00', line_width=2)\n",
+    "t_fit = np.linspace(0,1/dominant_freq,100)\n",
+    "bfig.line(t_fit, lomb.model(t_fit, dominant_freq), color='#1b9f00', line_width=2)\n",
     "\n",
     "# Labeling the axes\n",
     "bfig.xaxis.axis_label = \"Phase (days)\"\n",
@@ -773,7 +774,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/notebooks/MAST/TESS/interm_tasc_lc/interm_tasc_lc.ipynb
+++ b/notebooks/MAST/TESS/interm_tasc_lc/interm_tasc_lc.ipynb
@@ -1,0 +1,832 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"title_ID\"></a>\n",
+    "# Intermediate: Finding Flares and Variable Stars in TASC Light Curves\n",
+    "\n",
+    "This notebook demostrates MAST's programmatic tools for accessing TESS time series data while exploring a flaring star from the literature and a nearby variable star.  \n",
+    "\n",
+    "The following topics will be covered:\n",
+    "- Using the MAST API to get mission pipeline and TASOC light curves\n",
+    "- Plotting TESS light curves in Python\n",
+    "- Using the MAST API to make an full frame image (FFI) cutout\n",
+    "- Creating a movie of TPF frames in Python\n",
+    "- Using the MAST API to get a list of TESS Input Catalog (TIC) sources\n",
+    "- Over plotting TIC sources on TESS images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Table of contents\n",
+    "\n",
+    "1. [Exploring a known stellar flare](#Exploring-a-stellar-flare) \n",
+    "    1. [Querying MAST](#Querying-MAST)\n",
+    "    2. [Downloading the light curves](#Downloading-the-light-curves)\n",
+    "    3. [Plotting the light curves](#Plotting-the-light-curves)\n",
+    "    4. [Making an animation](#Making-an-animation)\n",
+    "2. [Exploring a variable star](#Exploring-a-variable-star) \n",
+    "    1. [Overlaying TESS Input Catalog sources](#Overlaying-TIC-sources)\n",
+    "    2. [Getting the variable star light curve](#Getting-the-variable-star-light-curve)\n",
+    "    3. [Plotting the variable star light curve](#Plotting-the-variable-star-light-curve)\n",
+    "    4. [Finding the period of the variable star](#Finding-the-period)\n",
+    "4. [Additional Resources](#Additional-Resources)  \n",
+    "5. [About this Notebook](#About-this-Notebook) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Terminology\n",
+    "\n",
+    "- **TESS:** The Transiting Exoplanet Survey Satellite\n",
+    "- **TASOC:** The TESS Asteroseismic Science Operations Center\n",
+    "- **Sector:** TESS observed the sky in regions of 24x96 degrees along the southern, then northern, ecliptic hemispheres. Each of these regions is referred to as a \"sector\", starting with Sector 1.\n",
+    "- **TIC:** The TESS input catalog.\n",
+    "- **FFI:** TESS periodically reads out the entire frame of all four cameras, nominally every 30 minutes, and stores them as full frame images (FFIs).\n",
+    "- **TPF:** Target Pixel File, a fits file containing stacks of small images centered on a target, one image for every timestamp the telescope took data.\n",
+    "- **HDU:** Header Data Unit. A FITS file is made up of HDUs that contain data and metadata relating to the file. The first HDU is called the primary HDU, and anything that follows is considered an \"extension\", e.g., \"the first FITS extension\", \"the second FITS extension\", etc.\n",
+    "- **HDUList:** A list of HDUs that comprise a fits file.\n",
+    "- **BJD:** Barycentric Julian Date, the Julian Date that has been corrected for differences in the Earth's position with respect to the Solar System center of mass.\n",
+    "- **BTJD:** Barycentric TESS Julian Date, the timestamp measured in BJD, but offset by 2457000.0. I.e., BTJD = BJD - 2457000.0\n",
+    "- **WCS:** World Coordinate System, the coordinates that locate an astronomical object on the sky. \n",
+    "\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this notbook we will use the MAST module of Astroquery (`astroquery.mast`) to query and download data, and various `astropy` and `numpy` functions to manipulate the data. We will use both the `matplotlib` and `bokeh` plotting packages to visualize our data as they have different strengths and weaknesses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# For querying for data\n",
+    "from astroquery.mast import Tesscut, Observations, Catalogs\n",
+    "\n",
+    "# For manipulating data\n",
+    "import numpy as np\n",
+    "\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.io import fits\n",
+    "from astropy.wcs import WCS\n",
+    "from astropy.timeseries import LombScargle\n",
+    "from astropy.time import Time\n",
+    "import astropy.units as u\n",
+    "\n",
+    "# For matplotlib plotting\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as animation\n",
+    "\n",
+    "# For animation display\n",
+    "from matplotlib import rc\n",
+    "from IPython.display import HTML\n",
+    "rc('animation', html='jshtml')\n",
+    "\n",
+    "# For bokeh plotting\n",
+    "from bokeh import plotting\n",
+    "from bokeh.models import Span\n",
+    "plotting.output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploring a stellar flare\n",
+    "\n",
+    "### Selecting the flare\n",
+    "\n",
+    "We will start with a known flare from the literature, in this case from [G&uuml;nther, M. N., Zhan, Z., Seager, S.,\n",
+    "et al. 2019, arXiv e-prints, arXiv:1901.00443](https://arxiv.org/abs/1901.00443). We picked a particularly long flare to give us the best chance of finding it in the 30 minute cadence data as well as the 2 minute cadence data.\n",
+    "\n",
+    "We've made note of the TIC ID and sector for our flare of interest, as well as its peak time in BJD format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tic_id = 141914082\n",
+    "sector = 1\n",
+    "\n",
+    "tpeak = 2458341.89227 # Julian Day"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Querying MAST\n",
+    "\n",
+    "#### Mission light curves\n",
+    "\n",
+    "Using the `query_criteria` function in the `astroquery.mast.Observations` class, we will specify that we are looking for TESS mission data using the `obs_collection` argument, that we want a specific TIC ID using the `target_name` argument, and that we want observations from a particular sector using the `sequence_number` argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mission_res = Observations.query_criteria(obs_collection=\"TESS\", \n",
+    "                                          target_name=tic_id, \n",
+    "                                          sequence_number=sector)\n",
+    "mission_res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### TASOC light curves\n",
+    "\n",
+    "In addition to mission pipeline data, MAST also hosts a variety of community contributed High Level Science Products (HLSPs), all of which are given the mission (`obs_collection`) \"HLSP\". In this case we will specifically search for HLSPs in the TESS project, which will return the light curves provided by the TASOC (note the `provenance_name` of \"TASOC\"). All other arguments remain the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tasoc_res = Observations.query_criteria(target_name=tic_id, \n",
+    "                                        obs_collection=\"HLSP\", \n",
+    "                                        project=\"TESS\",\n",
+    "                                        sequence_number=sector)\n",
+    "tasoc_res['dataproduct_type',\"obs_collection\",\"target_name\",\"t_exptime\",\"filters\",\n",
+    "          \"provenance_name\",\"project\",\"sequence_number\",\"instrument_name\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This query returns two light curves. To understand the difference between the two light curves we look at the `t_exptime` column, and note the different values. These exposure times correspond to 2 minutes (short cadence) and 30 minutes (long cadence). We will explore both light curves."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Downloading the light curves\n",
+    "\n",
+    "For the rest of this notebook we will work with the TASOC light curves only, although we could do the same analysis on the mission light curves.\n",
+    "\n",
+    "#### Querying for the list of associated data products\n",
+    "\n",
+    "Each observation may have one or more associated data products. In the case of the TASOC light curves, there is simply a single light curve file for each observation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tasoc_prod = Observations.get_product_list(tasoc_res)\n",
+    "tasoc_prod[\"dataproduct_type\", \"description\", \"dataURI\", \"size\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Downloading files\n",
+    "\n",
+    "We can choose do download some or all of the associated data files, in this case since we just have the two light curves, we will download all of the products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tasoc_manifest = Observations.download_products(tasoc_prod)\n",
+    "tasoc_manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plotting the light curves\n",
+    "\n",
+    "We will use the `bokeh` plotting library so that we can have interactivity, and will plot both the 2 minute and 30 minute cadence data together. \n",
+    "\n",
+    "We can tell which file corresponds to which cadence length by examining the filenames and noting that one contains `c0120` (2 minutes) and the other `c1800` (30 minutes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Loading the short cadence light curve\n",
+    "hdu = fits.open(tasoc_manifest[\"Local Path\"][0])\n",
+    "short_cad_lc = Table(hdu[1].data)\n",
+    "hdu.close()\n",
+    "\n",
+    "# Loading the long cadence light curve\n",
+    "hdu = fits.open(tasoc_manifest[\"Local Path\"][1])\n",
+    "long_cad_lc = Table(hdu[1].data)\n",
+    "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bfig = plotting.figure(plot_width=850, plot_height=300, title=f\"Detrended Lightcurve (TIC{tic_id})\")\n",
+    "\n",
+    "# Short cadence\n",
+    "bfig.circle(short_cad_lc[\"TIME\"],short_cad_lc[\"FLUX_RAW\"], fill_color=\"black\",size=2, line_color=None)\n",
+    "bfig.line(short_cad_lc[\"TIME\"],short_cad_lc[\"FLUX_RAW\"], line_color='black')\n",
+    "\n",
+    "# Long cadence\n",
+    "bfig.circle(long_cad_lc[\"TIME\"],long_cad_lc[\"FLUX_RAW\"], fill_color=\"#0384f7\",size=6, line_color=None)\n",
+    "bfig.line(long_cad_lc[\"TIME\"],long_cad_lc[\"FLUX_RAW\"], line_color='#0384f7')\n",
+    "\n",
+    "# Marking the flare (tpeak is in BJD, while the time column in the light curve is BTJD, so we must convert)\n",
+    "vline = Span(location=(tpeak - 2457000), dimension='height', line_color='#bf006e', line_width=3)\n",
+    "bfig.renderers.extend([vline])\n",
+    "\n",
+    "# Labeling the axes\n",
+    "bfig.xaxis.axis_label = \"Time (BTJD)\"\n",
+    "bfig.yaxis.axis_label = \"Flux\"\n",
+    "\n",
+    "plotting.show(bfig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Experiment with the controls on the right to zoom in and and pan around on this light curve to look at the marked flare and other features (some sort of periodic feature maybe?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Making an animation\n",
+    "\n",
+    "Looking at the above plot we can see the flare event in both the long and short cadence light curves. Since we can see it even in the 30 minute data, we should be able to make an animation of the area around the flaring star and see the flare happen.\n",
+    "\n",
+    "We will use TESScut, the MAST cutout tool for full-frame images to cutout the area around the flaring star across the entire sector, and then make a movie that shows how it changes over time.\n",
+    "\n",
+    "We will use the `astroquery.mast` __[Tesscut](https://astroquery.readthedocs.io/en/latest/mast/mast.html#tesscut)__ class to make this cutout.  \n",
+    "We will use two functions:\n",
+    "- Find the sky coordinate of our flare star: `Observations._resolve_object`\\*\n",
+    "- Query for cutouts and get the result as a list of HDUList objects: `Tesscut.get_cutouts` \\*\\*\n",
+    "\n",
+    "\\* `Observations._resolve_object` is a private (not documented) function which is being removed in favor of the public function `Observations.resolve_object` in the next Astroquery release.\n",
+    "\n",
+    "\\*\\* We must start by finding the sky coordinate of our star, however starting with the next Astroquery release, `Tesscut` functions will be able to take an object name such as a TIC ID as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coord = Observations._resolve_object(f\"TIC {tic_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Requesting a cutout target pixel file. **\n",
+    "\n",
+    "This query will return a list of `HDUList` objects, each of which is the cutout target pixel file (TPF) for a single sector. In this case, because we specified a single sector we know that the resulting list will only have one element and can pull it out directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutout_hdu = Tesscut.get_cutouts(coordinates=coord, size=40, sector=1)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutout_hdu.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A TESScut TPF has three extensions:\n",
+    "- No. 0 (Primary): This HDU contains meta-data related to the entire file.\n",
+    "- No. 1 (Pixels): This HDU contains a binary table that holds data like cutout image arrays and times. We will extract information from here to get our set of cutout images.\n",
+    "- No. 2 (Aperture): This HDU contains the image extension with data collected from the aperture. We will use this extension to get the WCS associated with out cutout.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutout_table = Table(cutout_hdu[1].data)\n",
+    "cutout_table.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Pixels extension contains the cutout data table, which has a number of columns. For our puposes we care about the \"TIME\" column which has the observation times in BTJD, and the \"FLUX\" column which contains the cutout images (they  are calibrated, but not background subtracted)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exploring the cutout time series\n",
+    "\n",
+    "We want to explore what is happening within our cutout area over the time that the flare occurs, so we will make an animated plot of the cutout frames.\n",
+    "\n",
+    "We can't make a movie of the whole sector (it would take too long), so we will choose only the time range around the flare.\n",
+    "\n",
+    "Use the light curve plot to figure out what time range you want to animate, or use our selections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_btjd = 1341.5\n",
+    "end_btjd = 1342.5\n",
+    "\n",
+    "start_index = (np.abs(cutout_table['TIME'] - start_btjd)).argmin()\n",
+    "end_index = (np.abs(cutout_table['TIME'] - end_btjd)).argmin()\n",
+    "\n",
+    "print(f\"Frames {start_index}-{end_index} ({end_index-start_index} frames)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Looking at the animated cutout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_animation(data_array, start_frame=0, end_frame=None, vmin=None, vmax=None, delay=50):\n",
+    "    \"\"\"\n",
+    "    Function that takes an array where each frame is a 2D image array and make an animated plot\n",
+    "    that runs through the frames.\n",
+    "    \n",
+    "    Note: This can take a long time to run if you have a lot of frames.    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_array : array\n",
+    "        Array of 2D images.\n",
+    "    start_frame : int\n",
+    "        The index of the initial frame to show. Default is the first frame.\n",
+    "    end_frame : int\n",
+    "        The index of the final frame to show. Default is the last frame.\n",
+    "    vmin : float\n",
+    "        Data range min for the colormap. Defaults to data minimum value.\n",
+    "    vmax : float\n",
+    "        Data range max for the colormap. Defaults to data maximum value.\n",
+    "    delay: \n",
+    "        Delay before the next frame is shown in milliseconds.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    response : `animation.FuncAnimation`\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    if not vmin:\n",
+    "        vmin = np.min(data_array)\n",
+    "    if not vmax:\n",
+    "        vmax = np.max(data_array)\n",
+    "        \n",
+    "    if not end_frame:\n",
+    "        end_frame = len(data_array) - 1 # set to the end of the array\n",
+    "        \n",
+    "    num_frames = end_frame - start_frame + 1 # include the end frame\n",
+    "        \n",
+    "    def animate(i, fig, ax, binarytab, start=0):\n",
+    "        \"\"\"Function used to update the animation\"\"\"\n",
+    "        ax.set_title(\"Epoch #\" + str(i+start))\n",
+    "        im = ax.imshow(binarytab[i+start], cmap=plt.cm.YlGnBu_r, vmin=vmin, vmax=vmax)\n",
+    "        return im,\n",
+    "    \n",
+    "    # Create initial plot.\n",
+    "    fig, ax = plt.subplots(figsize=(10,10))\n",
+    "    ax.imshow(data_array[start_frame], cmap=plt.cm.YlGnBu_r, vmin=vmin, vmax=vmax)\n",
+    "\n",
+    "    ani = animation.FuncAnimation(fig, animate, fargs=(fig, ax, data_array, start_frame), frames=num_frames, \n",
+    "                                  interval=delay, repeat_delay=1000)\n",
+    "    \n",
+    "    plt.close()\n",
+    "    \n",
+    "    return ani"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "make_animation(cutout_table['FLUX'], start_index, end_index, vmax=700, delay=150)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see three things in this plot:\n",
+    "- The flare that occures in frames 740-743\n",
+    "- An aberration that appears in frame 754\n",
+    "- A variable star pulsing in the lower right corner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploring a variable star\n",
+    "\n",
+    "Now we will look more closely at the variable star we can see in the animation. We will use the TESS Input Catalog (TIC) to figure out the TESS ID of the variable star, and then using that ID pull down and explore the star's light curve from MAST. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Overlaying TIC sources\n",
+    "\n",
+    "First we will use the `astroquery.mast.Catalog` class to query the TESS Input Catalog (TIC) and get a list of sources that appear in our cutout.\n",
+    "\n",
+    "Here we do a simple cone search and the apply a magnitude limit. Play around with the magnitude limit to see how it changes the number of sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources = Catalogs.query_object(catalog=\"TIC\", objectname=f\"TIC {tic_id}\", radius=10*u.arcmin)\n",
+    "sources = sources[sources[\"Tmag\"] < 12]\n",
+    "print(f\"Number of sources: {len(sources)}\")\n",
+    "print(sources)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plotting sources on an individual cutout\n",
+    "\n",
+    "We will get the WCS infomation associated with our cutout from the Aperture extension, and use it to make a WCS-aware plot of a single cutout image. Then we display the image and sources together, and label the sources with their row number in the catalog table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutout_wcs = WCS(cutout_hdu[2].header)\n",
+    "cutout_img = cutout_table[\"FLUX\"][start_index]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(subplot_kw={'projection':cutout_wcs})\n",
+    "fig.set_size_inches(10,10)\n",
+    "plt.grid(color='white', ls='solid')\n",
+    "    \n",
+    "# Setup WCS axes.\n",
+    "xcoords = ax.coords[0]\n",
+    "ycoords = ax.coords[1]\n",
+    "xcoords.set_major_formatter('d.ddd')\n",
+    "ycoords.set_major_formatter('d.ddd')\n",
+    "xcoords.set_axislabel(\"RA (deg)\")\n",
+    "ycoords.set_axislabel(\"Dec (deg)\")\n",
+    "ax.imshow(cutout_img, cmap=plt.cm.YlGnBu_r,vmin=0,vmax=700)\n",
+    "ax.plot(sources['ra'],sources['dec'],'x',transform=ax.get_transform('icrs'),color=\"red\")\n",
+    "\n",
+    "# Annotating the sources with their row nnumber in the sources table\n",
+    "for i,star in enumerate(sources):\n",
+    "    ax.text(star['ra']+0.01,star['dec'],i,transform=ax.get_transform('icrs'))\n",
+    "\n",
+    "ax.set_xlim(0,cutout_img.shape[1]-1)\n",
+    "ax.set_ylim(cutout_img.shape[0]-1,0)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The variable star is row 4 in the catalog sources table (note that if you changed the magnitude threshold the variale star may be in a different row)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources[\"ID\",\"ra\",\"dec\"][4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting the variable star light curve\n",
+    "\n",
+    "Again, we will look specifically for the TASOC light curve(s) associated with this star, rather than the mission pipeline ones. Below we go through the same process as in the [Downloading the light curves](#Downloading-the-light-curves) section to search for the observation, then find the associated data products, and download them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variable_tic_id = sources[\"ID\"][4]\n",
+    "\n",
+    "variable_res = Observations.query_criteria(target_name=variable_tic_id, \n",
+    "                                        obs_collection=\"HLSP\", \n",
+    "                                        filters=\"TESS\")\n",
+    "print(f\"Number of tasoc light curves for {variable_tic_id}: {len(variable_res)}\\n\")\n",
+    "\n",
+    "        \n",
+    "variable_prod = Observations.get_product_list(variable_res[0])\n",
+    "variable_manifest = Observations.download_products(variable_prod)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this time there is only one (30 minute cadence) TASOC light curve. This is because this star was not one od the targets that TESS observed at the shorter cadence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu = fits.open(variable_manifest[\"Local Path\"][0])\n",
+    "variable_lc = Table(hdu[1].data)\n",
+    "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plotting the variable star light curve\n",
+    "\n",
+    "We will again plot the light curve using bokeh so that we have interactivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bfig = plotting.figure(plot_width=850, plot_height=300, title=f\"Detrended Lightcurve (TIC{variable_tic_id})\")\n",
+    "\n",
+    "bfig.circle(variable_lc[\"TIME\"],variable_lc[\"FLUX_RAW\"], fill_color=\"black\",size=4, line_color=None)\n",
+    "bfig.line(variable_lc[\"TIME\"],variable_lc[\"FLUX_RAW\"], line_color='black')\n",
+    "\n",
+    "# Labeling the axes\n",
+    "bfig.xaxis.axis_label = \"Time (BTJD)\"\n",
+    "bfig.yaxis.axis_label = \"Flux\"\n",
+    "\n",
+    "plotting.show(bfig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That looks variable all right!\n",
+    "\n",
+    "### Finding the period\n",
+    "\n",
+    "We'll run a Lomb Scargle priodogram on this light curve to see if we can quantify the periodic behavior. To do this we will use the `astropy.timeseries` class [LombScargle](https://docs.astropy.org/en/stable/timeseries/lombscargle.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lomb = LombScargle(variable_lc[\"TIME\"], variable_lc[\"FLUX_RAW\"])\n",
+    "frequency, power = lomb.autopower()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plotting the periodogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bfig = plotting.figure(plot_width=850, plot_height=300, x_axis_type=\"log\", x_range=(0.008, 1),\n",
+    "                       title=f\"Periodogram (TIC{variable_tic_id})\")\n",
+    "\n",
+    "bfig.line(1/frequency, power, line_color='black')\n",
+    "\n",
+    "# Labeling the axes\n",
+    "bfig.xaxis.axis_label = \"Period\"\n",
+    "bfig.yaxis.axis_label = \"Power\"\n",
+    "\n",
+    "plotting.show(bfig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Phasing on the highest power period\n",
+    "\n",
+    "We will pick out the highest powered period in the abover periodogram and phase the stellar light curve on that period."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "period = 1/frequency[np.argmax(power)].value\n",
+    "period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bfig = plotting.figure(plot_width=850, plot_height=300, title=f\"Phased Lightcurve (TIC{variable_tic_id})\")\n",
+    "\n",
+    "# Plotting the phased light curve\n",
+    "bfig.circle(variable_lc[\"TIME\"]%period,variable_lc[\"FLUX_RAW\"], fill_color=\"black\",size=4, line_color=None)\n",
+    "\n",
+    "# Plotting the periodic fit\n",
+    "t_fit = np.linspace(0,period,100)\n",
+    "bfig.line(t_fit, lomb.model(t_fit, 1/period), color='#1b9f00', line_width=2)\n",
+    "\n",
+    "# Labeling the axes\n",
+    "bfig.xaxis.axis_label = \"Phase (days)\"\n",
+    "bfig.yaxis.axis_label = \"Flux\"\n",
+    "\n",
+    "plotting.show(bfig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Resources\n",
+    "\n",
+    "- [Main TESS page at MAST](https://archive.stsci.edu/tess)\n",
+    "- [MAST Astroquery documentation](https://astroquery.readthedocs.io/en/latest/mast/mast.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** C. E. Brasseur, STScI Software Engineer\n",
+    "<br>**Updated On:** 2019-08-02"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#title_ID)\n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/MAST/TESS/interm_tasc_lc/requirements.txt
+++ b/notebooks/MAST/TESS/interm_tasc_lc/requirements.txt
@@ -1,0 +1,5 @@
+astropy>=3.2.1
+astroquery==0.3.9
+bokeh>=0.12.16
+matplotlib>=2.2.2
+numpy>=1.13.3


### PR DESCRIPTION
Turned my TASC presentation notebook into an example notebook.

Works through getting TASC light curves from MAST using astroquery, using tesscut to make cutouts, and overplotting TIC sources.