### PR TITLE
TESS cutouts with requests: download from only one sector

### DIFF
--- a/notebooks/MAST/TESS/interm_tesscut_requests/interm_tesscut_requests.ipynb
+++ b/notebooks/MAST/TESS/interm_tesscut_requests/interm_tesscut_requests.ipynb
@@ -171,7 +171,7 @@
    "source": [
     "<a id=\"tesscut_ID\"></a>\n",
     "## Request a FFI Cutout with Astrocut\n",
-    "Astrocut is the tool that runs the cutout service around the RA and Dec that were requested. It delivers a zipped file containing a cutout for each set of FFIs as listed above. It is also possible to request only one sector using the \"sector\" parameter.  For tesscut x refers to the CCD columns and y refers to the CCD rows. Distance can be input in a variety of units, I picked pixels (\"px\").\n",
+    "Astrocut is the tool that runs the cutout service around the RA and Dec that were requested. It delivers a zipped file containing a cutout for each set of FFIs as listed above. It is also possible to request only one sector using the \"sector\" parameter,which we will do here.  For tesscut x refers to the CCD columns and y refers to the CCD rows. Distance can be input in a variety of units, I picked pixels (\"px\").\n",
     "\n",
     "< Response [200] > means that your request succeeded."
    ]
@@ -183,7 +183,7 @@
    "outputs": [],
    "source": [
     "myparams = {\"ra\":Ra, \"dec\":Dec, \"x\":35, \"y\":45, \n",
-    "           \"units\":\"px\", \"sector\":\"All\"}\n",
+    "           \"units\":\"px\", \"sector\":1}\n",
     "\n",
     "url = urlroot + \"/astrocut\"\n",
     "\n",
@@ -344,7 +344,7 @@
     "<a id=\"about_ID\"></a>\n",
     "## About this Notebook\n",
     "**Author:** Susan E. Mullally, STScI Archive Scientist\n",
-    "<br>**Updated On:** 2018-11-29"
+    "<br>**Updated On:** 2019-12-6"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Small change: instead of downloading all available cutouts, just download from sector 1. This is so that we are downloading a smaller file (40 MB vs 216 MB).

Prompted by https://github.com/spacetelescope/notebooks/issues/122.