### PR TITLE
Migration to PyVO for MAST TAP notebooks

### DIFF
--- a/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
+++ b/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
@@ -42,9 +42,9 @@
    "source": [
     "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns retunred from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astroquery TAP/TAP+ client, which was developed by the ESAC Space Data Centre for working with the GAIA catalog, but is interoperable with other valid TAP services, including those at MAST. As an astroquery project, TAP+ documentation is available at ReadTheDocs: http://astroquery.readthedocs.io/en/latest/utils/tap.html\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
     "\n",
-    "We'll be using TAP+ to call the most recent version (3) of the Hubble Source Catalog TAP service at MAST. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/hcasjobs/\n",
+    "We'll be using PyVO to call the most recent version (3) of the Hubble Source Catalog TAP service at MAST. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/hcasjobs/\n",
     "\n"
    ]
   },
@@ -59,13 +59,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the astroquery TapPlus library as our client to the data service.\n",
-    "from astroquery.utils.tap.core import TapPlus\n",
+    "import pyvo as vo\n",
     "\n",
     "## For handling ordinary astropy Tables in responses\n",
     "from astropy.table import Table\n",
@@ -83,7 +80,12 @@
     "from IPython.core.display import HTML\n",
     "\n",
     "# For the second example: kernel density estimates\n",
-    "from scipy.stats import gaussian_kde"
+    "from scipy.stats import gaussian_kde\n",
+    "\n",
+    "\n",
+    "# suppress unimportant unit warnings from many TAP services\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", module=\"astropy.io.votable.*\")"
    ]
   },
   {
@@ -109,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HSC_service = TapPlus(url=\"http://vao.stsci.edu/HSCTAP/tapservice.aspx\")"
+    "HSC_service = vo.dal.TAPService(\"http://vao.stsci.edu/hsctap/tapservice.aspx\")"
    ]
   },
   {
@@ -118,9 +120,9 @@
    "source": [
     "### Querying for Table Schema Information\n",
     "    \n",
-    "TAP services are self-describing, which means the service itself can be asked for its schema and documentation about it. Since the hubble Source Catalog does not follow a data model described by a standard, this is the best way to see what tables and columns we have available to then query based on geometry or other filters. \n",
+    "TAP services are self-describing, which means the service itself can be asked for its schema and documentation about it. Since the Hubble Source Catalog does not follow a data model described by a standard, this is the best way to see what tables and columns we have available to then query based on geometry or other filters. \n",
     "    \n",
-    "The main view for HSC, SumMagAper2CatView, is extremely wide, containing columns for all potential filters, each of which may have null data. So in showing our query results, we will cut off the display with \"...\" marks. You can change the 'if' line to show the rest of these columns."
+    "Note that several views for HSC, including the main science table SumMagAper2CatView, are extremely wide, containing columns for all potential filters, each of which may have null data. The ability to filter queries based on only columns we want, or that aren't null, makes TAP services more flexible and potentially faster."
    ]
   },
   {
@@ -129,19 +131,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HSC_tables = HSC_service.load_tables()\n",
-    "print('\\n')\n",
-    "for table in HSC_tables:\n",
-    "    if( table.name == 'dbo.SumMagAper2CatView'):\n",
-    "        print(table)\n",
-    "        print('\\n')\n",
-    "        for i, column in enumerate(table.columns):\n",
-    "            #only show the first 30 and last 10 columns\n",
-    "            if i < 30 or i > len(table.columns)-10:\n",
-    "                print(column.name)\n",
-    "            #skip display for the middle column names\n",
-    "            elif i == 30:\n",
-    "                print(\"...\")"
+    "HSC_service.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HSC_tables = HSC_service.tables\n",
+    "for tablename in HSC_tables.keys():\n",
+    "    if \"SumMagAper2CatView\" in tablename:  \n",
+    "        HSC_tables[tablename].describe()\n",
+    "        print(\"Columns={}\".format(sorted([k.name for k in HSC_tables[tablename].columns ])))\n",
+    "        print(\"----\")"
    ]
   },
   {
@@ -164,13 +168,12 @@
    },
    "outputs": [],
    "source": [
-    "job = HSC_service.launch_job(\"\"\"\n",
+    "results = HSC_service.run_async(\"\"\"\n",
     "SELECT TOP 10 MatchRA, MatchDec, TargetName, StartTime, StopTime\n",
     "FROM dbo.SumMagAper2CatView\n",
     "WHERE CONTAINS(POINT('ICRS', MatchRA, MatchDec),CIRCLE('ICRS',129.23,7.95,0.1))=1\n",
     "  \"\"\")\n",
-    "HSC_results = job.get_results()\n",
-    "HSC_results"
+    "results.to_table()"
    ]
   },
   {
@@ -186,15 +189,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job = HSC_service.launch_job(\"\"\"\n",
+    "results = HSC_service.run_async(\"\"\"\n",
     "SELECT TOP 10 MatchID, MatchRA, MatchDec, TargetName, StartTime, StopTime, TargetName \n",
     "FROM dbo.SumMagAper2CatView\n",
     "WHERE \n",
     "CONTAINS(POINT('ICRS', MatchRA, MatchDec),CIRCLE('ICRS',129.23,7.95,0.1))=1\n",
     "AND StartTime > '2015-01-01' AND StopTime < '2015-04-01'\n",
     "\"\"\")\n",
-    "HSC_results = job.get_results()\n",
-    "HSC_results"
+    "results.to_table()"
    ]
   },
   {
@@ -204,7 +206,7 @@
     "***\n",
     "### Use Case: Plotting a light curve for the most variable object in a field\n",
     "\n",
-    "A use case example: search for objects with 10 or more ACS F475W magnitudes in a crowded field near IC 1613 (see <a href=\"http://archive.stsci.edu/hst/hsc/help/use_case_3_v2.html\">HSC Use Case 3</a>). Then get the individual A_F475W measurements for the most variable object in the list and plot the light curve. Note we are using asynchronous query mode for this example rather than synchronous, because it has a longer allowed timeout, which can be useful for large or complex queries."
+    "A use case example: search for objects with 10 or more ACS F475W magnitudes in a crowded field near IC 1613 (see <a href=\"http://archive.stsci.edu/hst/hsc/help/use_case_3_v2.html\">HSC Use Case 3</a>). Then get the individual A_F475W measurements for the most variable object in the list and plot the light curve. Note we must use asynchronous query mode for this example rather than synchronous, because it has a longer allowed timeout, which can be useful for large or complex queries."
    ]
   },
   {
@@ -213,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job = HSC_service.launch_job_async(\"\"\"\n",
+    "results = HSC_service.run_async(\"\"\"\n",
     "SELECT MatchID, MatchRA, MatchDec, TargetName, NumImages, NumVisits, A_F475W, A_F475W_MAD, A_F475W_N\n",
     "FROM dbo.SumMagAper2CatView\n",
     "WHERE \n",
@@ -221,9 +223,16 @@
     "   AND\n",
     "   CONTAINS(POINT('ICRS', MatchRA, MatchDec),CIRCLE('ICRS',16.117562,2.162183,0.1))=1\n",
     "   \"\"\")\n",
-    "HSC_results = job.get_results()\n",
-    "HSC_results\n",
-    "\n",
+    "HSC_results = results.to_table()\n",
+    "HSC_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.rcParams.update({'font.size': 16})\n",
     "plt.figure(1,(10,6))\n",
     "plt.scatter(HSC_results['A_F475W'], HSC_results['A_F475W_MAD'])\n",
@@ -243,7 +252,7 @@
     "print(HSC_results[i])\n",
     "\n",
     "matchid = HSC_results['MatchID'][i]\n",
-    "job = HSC_service.launch_job_async(\"\"\"\n",
+    "details = HSC_service.run_async(\"\"\"\n",
     "SELECT SourceID, ImageID, SourceRA, SourceDec, D, Filter, Detector, MagAper2, StartMJD\n",
     "FROM dbo.DetailedCatalog\n",
     "WHERE \n",
@@ -251,7 +260,7 @@
     "   AND Detector='ACS/WFC' AND Filter='F475W' AND Det='Y'\n",
     "ORDER BY StartMJD\n",
     "\"\"\".format(matchid))\n",
-    "HSC_details = job.get_results()\n",
+    "HSC_details = details.to_table()\n",
     "HSC_details\n",
     "\n",
     "plt.rcParams.update({'font.size': 16})\n",
@@ -279,13 +288,13 @@
    "source": [
     "t0 = time.time()\n",
     "\n",
-    "job = HSC_service.launch_job_async(\"\"\"\n",
+    "results = HSC_service.run_async(\"\"\"\n",
     "SELECT MatchID, MatchRA, MatchDec, CI, A_F555W, A_F814W\n",
     "FROM dbo.SumMagAper2CatView\n",
     "WHERE A_F555W_N > 0 and A_F814W_N > 0\n",
     "    AND CONTAINS(POINT('ICRS', MatchRA, MatchDec),CIRCLE('ICRS',13.1866,-72.8286,0.25))=1\n",
     "   \"\"\")\n",
-    "HSC_results = job.get_results()\n",
+    "HSC_results = results.to_table()\n",
     "print(\"Query completed in {:.1f} sec\".format(time.time()-t0))\n",
     "HSC_results"
    ]
@@ -326,9 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Sort the points by density, so that the densest points are plotted last\n",
@@ -371,9 +378,10 @@
     "* IVOA standard for querying astronomical data in tabular format, with geometric search support\n",
     "* http://www.ivoa.net/documents/latest/ADQL.html\n",
     "\n",
-    "## TapPlus \n",
-    "* Module created by ESAC Space Data Centre\n",
-    "* http://astroquery.readthedocs.io/en/latest/utils/tap.html"
+    "## PyVO\n",
+    "* an affiliated package for astropy\n",
+    "* find and retrieve astronomical data available from archives that support standard IVOA virtual observatory service protocols.\n",
+    "* https://pyvo.readthedocs.io/en/latest/index.html"
    ]
   },
   {
@@ -389,7 +397,7 @@
    "source": [
     "## About this Notebook\n",
     "**Authors:** Rick White & Theresa Dower, STScI Archive Scientist & Software Engineer\n",
-    "**Updated On:** 11/23/2018"
+    "**Updated On:** 01/08/2020"
    ]
   },
   {

--- a/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
+++ b/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
@@ -40,9 +40,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns retunred from cone, image, and spectral services.\n",
+    "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic/spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns returned from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://pyvo.readthedocs.io\n",
     "\n",
     "We'll be using PyVO to call the most recent version (3) of the Hubble Source Catalog TAP service at MAST. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/hcasjobs/\n",
     "\n"
@@ -102,7 +102,7 @@
    "source": [
     "### Connecting to a TAP Service\n",
     "\n",
-    "The TapPlus library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. This is the URL for the newest version of the Hubble Source Catalog TAP service."
+    "The PyVO library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. This is the URL for the newest version of the Hubble Source Catalog TAP service."
    ]
   },
   {

--- a/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
+++ b/notebooks/MAST/HSC/HSC_TAP/HSC_TAP.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "HSC_tables = HSC_service.tables\n",
     "for tablename in HSC_tables.keys():\n",
-    "    if \"SumMagAper2CatView\" in tablename:  \n",
+    "    if not \"tap_schema\" in tablename:  \n",
     "        HSC_tables[tablename].describe()\n",
     "        print(\"Columns={}\".format(sorted([k.name for k in HSC_tables[tablename].columns ])))\n",
     "        print(\"----\")"

--- a/notebooks/MAST/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.ipynb
+++ b/notebooks/MAST/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns returned from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astroquery TAP/TAP+ client, which was developed by the ESAC Space Data Centre for working with the GAIA catalog, but is interoperable with other valid TAP services, including those at MAST. As an astroquery project, TAP+ documentation is available at ReadTheDocs: http://astroquery.readthedocs.io/en/latest/utils/tap.html\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
     "\n",
     "We'll be using TAP+ to call the TAP service at MAST serving PanSTARRS 1 Data Release 2, now with individual detection information. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/ps1casjobs/\n",
     "\n"
@@ -58,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the astroquery TapPlus library as our client to the data service.\n",
-    "from astroquery.utils.tap.core import TapPlus\n",
+    "# Use the pyvo library as our client to the data service.\n",
+    "import pyvo as vo\n",
     "\n",
     "# For resolving objects with tools from MAST\n",
     "from astroquery.mast import Mast\n",
@@ -85,7 +85,12 @@
     "\n",
     "# To allow display tweaks for wider response tables\n",
     "from IPython.core.display import display\n",
-    "from IPython.core.display import HTML"
+    "from IPython.core.display import HTML\n",
+    "\n",
+    "# suppress unimportant unit warnings from many TAP services\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", module=\"astropy.io.votable.*\")\n",
+    "warnings.filterwarnings(\"ignore\", module=\"pyvo.utils.xml.elements\")"
    ]
   },
   {
@@ -109,7 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TAP_service = TapPlus(url=\"http://vao.stsci.edu/PS1DR2/tapservice.aspx\")"
+    "TAP_service = vo.dal.TAPService(\"http://vao.stsci.edu/PS1DR2/tapservice.aspx\")\n",
+    "TAP_service.describe()"
    ]
   },
   {
@@ -125,9 +131,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tables = TAP_service.load_tables(only_names=True)\n",
-    "for table in tables:\n",
-    "    print(table.name)"
+    "TAP_tables = TAP_service.tables\n",
+    "for tablename in TAP_tables.keys():\n",
+    "    if not \"tap_schema\" in tablename:  \n",
+    "        TAP_tables[tablename].describe()\n",
+    "        print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns ])))\n",
+    "        print(\"----\")"
    ]
   },
   {
@@ -158,14 +167,14 @@
    },
    "outputs": [],
    "source": [
-    "job = TAP_service.launch_job_async(\"\"\"\n",
+    "job = TAP_service.run_async(\"\"\"\n",
     "SELECT objID, RAMean, DecMean, nDetections, ng, nr, ni, nz, ny, gMeanPSFMag, rMeanPSFMag, iMeanPSFMag, zMeanPSFMag, yMeanPSFMag\n",
     "FROM dbo.MeanObjectView\n",
     "WHERE\n",
     "CONTAINS(POINT('ICRS', RAMean, DecMean),CIRCLE('ICRS',187.706,12.391,.2))=1\n",
     "AND nDetections > 1\n",
     "  \"\"\")\n",
-    "TAP_results = job.get_results()\n",
+    "TAP_results = job.to_table()\n",
     "TAP_results"
    ]
   },
@@ -199,8 +208,8 @@
     "\"\"\".format(ra,dec,radius)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "TAP_results = job.to_table()\n",
     "TAP_results"
    ]
   },
@@ -234,8 +243,8 @@
     "\"\"\".format(objid)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "detection_TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "detection_TAP_results = job.to_table()\n",
     "detection_TAP_results"
    ]
   },
@@ -491,8 +500,8 @@
     "\"\"\".format(ra,dec,radius)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "TAP_results = job.to_table()\n",
     "TAP_results"
    ]
   },
@@ -526,8 +535,8 @@
     "\"\"\".format(objid)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "detection_TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "detection_TAP_results = job.to_table()\n",
     "\n",
     "# add magnitude and difference from mean\n",
     "detection_TAP_results['magmean'] = 0.0\n",
@@ -635,8 +644,8 @@
     "\"\"\".format(ra,dec,radius)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "TAP_results = job.to_table()\n",
     "TAP_results"
    ]
   },
@@ -662,8 +671,8 @@
     "\"\"\".format(objid)\n",
     "print(query)\n",
     "\n",
-    "job = TAP_service.launch_job_async(query)\n",
-    "detection_TAP_results = job.get_results()\n",
+    "job = TAP_service.run_async(query)\n",
+    "detection_TAP_results = job.to_table()\n",
     "\n",
     "# add magnitude and difference from mean\n",
     "detection_TAP_results['magmean'] = 0.0\n",
@@ -772,9 +781,10 @@
     "* IVOA standard for querying astronomical data in tabular format, with geometric search support\n",
     "* http://www.ivoa.net/documents/latest/ADQL.html\n",
     "\n",
-    "## TapPlus \n",
-    "* Module created by ESAC Space Data Centre\n",
-    "* http://astroquery.readthedocs.io/en/latest/utils/tap.html"
+    "## PyVO\n",
+    "* an affiliated package for astropy\n",
+    "* find and retrieve astronomical data available from archives that support standard IVOA virtual observatory service protocols.\n",
+    "* https://pyvo.readthedocs.io/en/latest/index.html"
    ]
   },
   {
@@ -790,7 +800,7 @@
    "source": [
     "## About this Notebook\n",
     "**Authors:** Rick White & Theresa Dower, STScI Archive Scientist & Software Engineer\n",
-    "**Updated On:** 02/27/2019"
+    "**Updated On:** 01/09/2020"
    ]
   },
   {
@@ -824,7 +834,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "widgets": {
    "state": {},

--- a/notebooks/MAST/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.ipynb
+++ b/notebooks/MAST/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.ipynb
@@ -38,9 +38,9 @@
    "source": [
     "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns returned from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://pyvo.readthedocs.io\n",
     "\n",
-    "We'll be using TAP+ to call the TAP service at MAST serving PanSTARRS 1 Data Release 2, now with individual detection information. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/ps1casjobs/\n",
+    "We'll be using PyVO to call the TAP service at MAST serving PanSTARRS 1 Data Release 2, now with individual detection information. The schema is described within the service, and we'll show how to inspect it. The schema is also the same as the one available via the CasJobs interface, with an additional view added for the most common positional queries. CasJobs has its own copy of the schema documentation, which can be accessed through its own site: http://mastweb.stsci.edu/ps1casjobs/\n",
     "\n"
    ]
   },
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The TapPlus library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. This is the URL for the PanSTARRS 1 DR2 TAP service."
+    "The PyVO library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. This is the URL for the PanSTARRS 1 DR2 TAP service."
    ]
   },
   {
@@ -156,7 +156,7 @@
     "\n",
     "Note that the results are restricted to objects with `nDetections>1`, where `nDetections` is the total number of times the object was detected on the single-epoch images in any filter at any time.  Objects with `nDetections=1` tend to be  artifacts, so this is a quick way to eliminate most spurious objects from the catalog.\n",
     "\n",
-    "This query runs in TAP's asynchronous mode, which is a queued batch mode with some overhead and longer timeouts, useful for big catalogs like PanSTARRS. It may not be necessary for all queries to PS1 DR2, but the TAP+ client can automatically handle the additional processing required over synchronous mode."
+    "This query runs in TAP's asynchronous mode, which is a queued batch mode with some overhead and longer timeouts, useful for big catalogs like PanSTARRS. It may not be necessary for all queries to PS1 DR2, but the PyVO client can automatically handle the additional processing required over synchronous mode."
    ]
   },
   {
@@ -194,7 +194,7 @@
    "outputs": [],
    "source": [
     "objname = 'KQ UMa'\n",
-    "coords = Mast._resolve_object(objname)\n",
+    "coords = Mast.resolve_object(objname)\n",
     "ra,dec = coords.ra.value,coords.dec.value\n",
     "radius = 1.0/3600.0 # radius = 1 arcsec\n",
     "\n",
@@ -487,7 +487,7 @@
    "outputs": [],
    "source": [
     "objname = 'KIC 2161623'\n",
-    "coords = Mast._resolve_object(objname)\n",
+    "coords = Mast.resolve_object(objname)\n",
     "ra,dec = coords.ra.value,coords.dec.value\n",
     "radius = 1.0/3600.0 # radius = 1 arcsec\n",
     "\n",
@@ -631,7 +631,7 @@
    "outputs": [],
    "source": [
     "objname = 'KIC 8153568'\n",
-    "coords = Mast._resolve_object(objname)\n",
+    "coords = Mast.resolve_object(objname)\n",
     "ra,dec = coords.ra.value,coords.dec.value\n",
     "radius = 1.0/3600.0 # radius = 1 arcsec\n",
     "\n",

--- a/notebooks/MAST/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
+++ b/notebooks/MAST/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
@@ -41,9 +41,9 @@
    "source": [
     "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns retunred from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://pyvo.readthedocs.io\n",
     "\n",
-    "We'll be using TAP+ to call the CAOM Catalog TAP service at MAST and filter the results for TESS-related information. The schema for this catalog is an IVOA standard, and is also described within the service itself."
+    "We'll be using PyVO to call the CAOM Catalog TAP service at MAST and filter the results for TESS-related information. The schema for this catalog is an IVOA standard, and is also described within the service itself."
    ]
   },
   {
@@ -106,7 +106,7 @@
    "source": [
     "## Connecting to the TAP Service\n",
     "\n",
-    "The TapPlus library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. The CAOM TAP service at MAST has access to TESS FFI and time series, including file URLs for download."
+    "The PyVO library is able to connect to any TAP service, given the \"base\" URL as noted in metadata registry resources describing the service. The CAOM TAP service at MAST has access to TESS FFI and time series, including file URLs for download."
    ]
   },
   {

--- a/notebooks/MAST/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
+++ b/notebooks/MAST/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
@@ -41,10 +41,9 @@
    "source": [
     "Table Access Protocol (TAP) services allow more direct and flexible access to astronomical data than the simpler types of IVOA standard data services. Queries are built with the SQL-like Astronomical Data Query Language (ADQL), and can include geographic / spatial queries as well as filtering on other characteristics of the data. This also allows the user fine-grained control over the returned columns, unlike the fixed set of coumns retunred from cone, image, and spectral services.\n",
     "\n",
-    "For this example, we'll be using the astroquery TAP/TAP+ client, which was developed by the ESAC Space Data Centre for working with the GAIA catalog, but is interoperable with other valid TAP services, including those at MAST. As an astroquery project, TAP+ documentation is available at ReadTheDocs: http://astroquery.readthedocs.io/en/latest/utils/tap.html\n",
+    "For this example, we'll be using the astropy affiliated PyVO client, which is interoperable with other valid TAP services, including those at MAST. PyVO documentation is available at ReadTheDocs: https://readthedocs.org/projects/pyvo/\n",
     "\n",
-    "We'll be using TAP+ to call the CAOM Catalog TAP service at MAST and filter the results for TESS-related information. The schema for this catalog is an IVOA standard, and is also described within the service itself.\n",
-    "\n"
+    "We'll be using TAP+ to call the CAOM Catalog TAP service at MAST and filter the results for TESS-related information. The schema for this catalog is an IVOA standard, and is also described within the service itself."
    ]
   },
   {
@@ -61,8 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the astroquery TapPlus library as our client to the data service.\n",
-    "from astroquery.utils.tap.core import TapPlus\n",
+    "# Use the pyvo library as our client to the data service.\n",
+    "import pyvo as vo\n",
     "\n",
     "# For handling ordinary astropy Tables in responses\n",
     "from astropy.table import Table\n",
@@ -74,7 +73,13 @@
     "\n",
     "# To allow display tweaks for wider response tables\n",
     "from IPython.core.display import display\n",
-    "from IPython.core.display import HTML"
+    "from IPython.core.display import HTML\n",
+    "\n",
+    "# suppress unimportant unit warnings from many TAP services\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", module=\"astropy.io.votable.*\")\n",
+    "warnings.filterwarnings(\"ignore\", module=\"pyvo.utils.xml.elements\")\n",
+    "warnings.filterwarnings(\"ignore\", module=\"pyvo.io.vosi.vodataservice\")"
    ]
   },
   {
@@ -110,7 +115,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TAP_service = TapPlus(url=TAP_URL)"
+    "TAP_service = vo.dal.TAPService(TAP_URL)\n",
+    "TAP_service.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List available tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_tables = TAP_service.tables\n",
+    "for tablename in TAP_tables.keys():\n",
+    "    if not \"tap_schema\" in tablename:  \n",
+    "        TAP_tables[tablename].describe()\n",
+    "        print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns ])))\n",
+    "        print(\"----\")"
    ]
   },
   {
@@ -156,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job = TAP_service.launch_job_async(\"\"\"\n",
+    "job = TAP_service.run_async(\"\"\"\n",
     "            SELECT top 1 obs_id, s_region  \n",
     "            FROM dbo.caomobservation JOIN ivoa.obscore on dbo.caomobservation.observationID = ivoa.obscore.obs_id \n",
     "            WHERE collection = 'TESS' and trgType = 'FIELD' and \n",
@@ -164,9 +191,7 @@
     "            observationID like '{}'\n",
     "            \"\"\".format(sector, observationIDwildcard))\n",
     "\n",
-    "# Uncomment the line below to see the whole query with wildcards replaced\n",
-    "#print(job.parameters)\n",
-    "footprint_results = job.get_results()\n",
+    "footprint_results = job.to_table()\n",
     "footprint_results"
    ]
   },
@@ -215,7 +240,7 @@
    },
    "outputs": [],
    "source": [
-    "job = TAP_service.launch_job_async(\"\"\"\n",
+    "job = TAP_service.run_async(\"\"\"\n",
     "            SELECT target_name, sequenceNumber as sector, s_ra, s_dec, access_url, access_estsize, obs_id \n",
     "            FROM dbo.caomobservation JOIN ivoa.obscore on dbo.caomobservation.observationID = ivoa.obscore.obs_id \n",
     "            WHERE \n",
@@ -225,9 +250,7 @@
     "            ORDER BY obs_id\n",
     "            \"\"\".format(footprintShape, footprintVertices))\n",
     "\n",
-    "# Uncomment the line below to see the whole query with wildcards replaced\n",
-    "#print(job.parameters)\n",
-    "TAP_results = job.get_results()\n",
+    "TAP_results = job.to_table()\n",
     "TAP_results          "
    ]
   },
@@ -314,9 +337,10 @@
     "* http://www.opencadc.org/caom2/\n",
     "\n",
     "\n",
-    "## TapPlus \n",
-    "* Module created by ESAC Space Data Centre\n",
-    "* http://astroquery.readthedocs.io/en/latest/utils/tap.html"
+    "## PyVO\n",
+    "* an affiliated package for astropy\n",
+    "* find and retrieve astronomical data available from archives that support standard IVOA virtual observatory service protocols.\n",
+    "* https://pyvo.readthedocs.io/en/latest/index.html"
    ]
   },
   {
@@ -332,7 +356,7 @@
    "source": [
     "## About this Notebook\n",
     "**Authors:** Scott Fleming & Theresa Dower, STScI Archive Scientists & Software Engineer\n",
-    "**Updated On:** 07/09/2019"
+    "**Updated On:** 01/09/2020"
    ]
   },
   {


### PR DESCRIPTION
As the ESA TAP/TAPPlus library is being superceded by increased support for PyVO, we are moving MAST's notebooks previously using the TAP+ client functionality to PyVO's TAP client support. New notebooks from this point will be designed with PyVO in mind. 

Development outside these notebooks is still required to clear spurious warnings, particularly regarding units, which also produced similar warnings in the TAP+ system. Once these are handled, the warning 'ignore' can be removed.