### PR TITLE
Update README.md

### DIFF
--- a/notebooks/DrizzlePac/README.md
+++ b/notebooks/DrizzlePac/README.md
@@ -5,7 +5,7 @@ Improved drizzling tutorials are now available as Jupyter Notebooks and compatib
 
 The notebooks contain live code and visualizations, along with the usual narrative text, making them an ideal training exercise for new users. Each tutorial includes blocks of code demonstrating how to download the calibrated data from the MAST archive, how to align frames and update the image world coordinate system, and how to enhance the scientific value of the drizzled data products using advanced reprocessing techniques.
 
-The ten new notebooks available in this repository include the following topics:
+The eleven notebooks available in this repository include the following topics:
 
 * Initializing DrizzlePac
 * Aligning observations obtained in multiple HST visits
@@ -17,6 +17,7 @@ The ten new notebooks available in this repository include the following topics:
 * Drizzling WFPC2 data to use a single zeropoint
 * Sky matching features for HST mosaics
 * Aligning HST mosaics observed with multiple detectors
+* Using the updated astrometry solutions based on _Gaia_ positions
 
 Additional tutorials will be added to the repository as new software functionality becomes available, especially for advanced use cases. For additional assistance with DrizzlePac tools, users may submit a ticket to the [STScI Help Desk](https://stsci.service-now.com/hst?id=hst_index) or send an email to help@stsci.edu.
 


### PR DESCRIPTION
Adding the astrometry notebook to list of available DrizzlePac notebooks. This is a minor change to the DrizzlePac README file and can be merged quickly and without issues to other notebooks. 