### PR TITLE
Update COS DataDl.ipynb to reflect MAST's shift ftp -> ftps 

### DIFF
--- a/notebooks/COS/DataDl/DataDl.ipynb
+++ b/notebooks/COS/DataDl/DataDl.ipynb
@@ -339,9 +339,16 @@
     "- The green box highlights the \"Mark\" checkboxes for each dataset. \n",
     "- The black circle highlights the single dataset download button:\n",
     "   - **If you only need to download one or two datasets, you may simply click this button for each dataset**\n",
-    "   - Clicking the single dataset download button will attempt to open a \"pop-up\" window, which you must allow in order to download the file. Some browsers will require you to manually allow pop-ups.\n",
+    "   - Clicking the single dataset download button will attempt to open a \"pop-up\" window, which you must allow in order to download the file. Some browsers will require you to manually allow pop-ups.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"mastportSeriesD\"></a>\n",
+    "## 1.4. Searching for a Series of Observations on the MAST Portal\n",
     "\n",
-    "    \n",
     "<font size=\"4\"> <b>To download multiple datasets</b>:</font>\n",
     "The MAST portal acts a bit like an online shopping website, where you add your *data products* to the checkout *cart*/*basket*, then open up your cart to *checkout* and download the files.\n",
     "\n",

--- a/notebooks/COS/DataDl/DataDl.ipynb
+++ b/notebooks/COS/DataDl/DataDl.ipynb
@@ -113,9 +113,10 @@
    "source": [
     "<a id=\"mastD\"></a>\n",
     "## 1.1 The Classic HST Web Search\n",
-    "**A browser gui for searching *specifically* through [HST archival data can be found here](http://archive.stsci.edu/hst/search.php). We will be discussing *this* HST search below.**\n",
-    "\n",
-    "A newer and more general MAST gui, which also allows access to data from other telescopes such as TESS, but does not offer all HST-specific search parameters, is also available. We will discuss this interface in [Section 1.3](#mastportD).\n",
+    "**A browser gui for searching *specifically* through [HST archival data can be found here](http://archive.stsci.edu/hst/search.php). We will be discussing *this* HST search in the section below.**\n",
+    "As of September, 2021, two other portals also allow access to the same data:\n",
+    "* A newer HST-specific search page ([here](https://mast.stsci.edu/search/hst/ui/#/)). Most downloading difficulties have been solved with this new site, and upcoming versions of this tutorial will focus on its use.\n",
+    "* A more general MAST gui, which also allows access to data from other telescopes such as TESS, but does not offer all HST-specific search parameters. We will discuss this interface in [Section 1.3](#mastportD).\n",
     "\n",
     "The search page  of the HST interface is laid out as in fig. 1.1:\n",
     "### Fig 1.1\n",
@@ -154,33 +155,113 @@
     "<center><img src =figures/LCXV13050_res.png width =\"900\" title=\"MAST Archive dataset overview of LCXV13050\"> </center>\n",
     "\n",
     "Now we see a page like in Fig 1.5,\n",
-    "where we can either sign in with STScI credentials, or simply provide our email to proceed without credentials. Make sure to select \"Deliver the data to the Archive staging area\". Click \"Send Retrieval Request to STDADS\" and you will recieve an email with instructions on downloading with ftp. You will need to do this step from the command line.\n",
+    "where we can either sign in with STScI credentials, or simply provide our email to proceed without credentials. Generally, you may proceed anonymously, unless you are retrieving proprietary data to which you have access. Next, make sure to select \"Deliver the data to the Archive staging area\". Click \"Send Retrieval Request to ST-DADS\" and you will receive an email with instructions on downloading the data.\n",
     "\n",
     "### Fig 1.5\n",
     "<center><img src =figures/DownloadOptions.png width =\"900\" title=\"Download Options for LCXV13050\"> </center>\n",
     "\n",
-    "In the case of this request, the command to retrieve the data depends on how you are connected to the internet.\n",
+    "Now the data is \"staged\" on a MAST server, and you need to download it to your local computer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Downloading the staged data\n",
+    "We demonstrate three methods of downloading your staged data: \n",
+    "1. If your terminal supports it, you may [use the `wget` tool](#wgetDLD). \n",
+    "2. However if that does not work, we recommend [using a secure ftp client application](#download_ftps_cyduckD). \n",
+    "3. Finally, if you would instead like to download *staged data* programmatically, you may [use the Python `ftplib` package](#download_ftps_funcD), as described [here](https://archive.stsci.edu/ftp.html) in STScI's documentation of the MAST FTP Service. For your convenience, we have built the `download_anonymous_staged_data` function below, which will download anonymously staged data via ftps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=wgetDLD></a>\n",
+    "#### Downloading the staged data with `wget`\n",
+    "**If you are connected to the STScI network, either in-person or via a virtual private network (VPN), you should use the `wget` command as in the example below:**\n",
     "\n",
-    "**If you are connected to the STScI network, either in-person or via VPN , you should use the `wget` command as in the example below:**\n",
-    ">`wget -r --ftp-user=[anonymous] --ask-password [ftps://archive.stsci.edu/stage/anonymous/anonymous42822] --directory-prefix=[data_dir]`\n",
+    "`wget -r --ftp-user=anonymous --ask-password ftps://archive.stsci.edu/stage/anonymous/anonymous<directory_number> --directory-prefix=<data_dir>`\n",
     "\n",
-    "where the password was the email address used, and data_dir is the directory defined at the beginning of this Notebook. Now all the data is in a subdirectory `\"./archive.stsci.edu/stage/anonymous/anonymous42822/\"`\n",
+    "where `directory_number` is the number at the end of the anonymous path specified in the email you received from MAST and `data_dir` is the local directory where you want the downloaded data. \n",
+    "You will be prompted for a password. Type in the email address you used, then press enter/return.\n",
     "\n",
-    "**If you are not on the STScI network, downloading from the staged data is slightly more complicated and the best way to download staged data may vary.**\n",
-    "Below are several options for downloading this data. If you only need to download a few files, the Web Browser approach requires very little setup. If you are unfamiliar with ftp protocols and need to download many files, you may try using an ftp client, such as [Cyberduck](https://cyberduck.io).\n",
-    "However, if you are still having difficulty downloading the staged data you may simply opt to use the `Astroquery Python` method described in [Section 2](#astroqueryD).\n",
+    "Now all the data will be downloaded into a subdirectory of data_dir: `\"./archive.stsci.edu/stage/anonymous/anonymous<directory_number>/\"`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=download_ftps_cyduckD></a>\n",
+    "#### Downloading the staged data with a secure ftp client application (`CyberDuck`)\n",
+    "CyberDuck is an application which allows you to securely access data stored on another machine using ftps. To download your staged data using Cyberduck, first download the [Cyberduck](https://cyberduck.io) application (*free, with a recommended donation*). Next, open a new browser window (Safari, Firefox, and Google Chrome have all been shown to work,) and type in the following web address: `ftps://archive.stsci.edu/stage/anonymous<directory_number>`, where `directory_number` is the number at the end of the anonymous path specified in the email you received from MAST. For example, if the email specifies: \n",
+    "> \"The data can be found in the directory...  /stage/anonymous/anonymous42822\"\n",
     "\n",
-    "|Cyberduck ftp client|Mac/UNIX terminal or Windows CLI|Web Browser (*system-independent but must download files one-at-a-time*)| Direct Download from the *Newer* MAST Portal (simple but can be slow for large downloads)|\n",
-    "|-|-|-|-|\n",
-    "|Download the [Cyberduck](https://cyberduck.io/download/) software (*free with suggested donation*)|[install the gnu ftp tool](https://www.gnu.org/software/inetutils/) onto MacOS with [brew](https://brew.sh) (Windows users can skip this step)|Open a browser|Navigate to the [MAST portal](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) - described in detail in [Section 1.3](#mastportD)|\n",
-    "|Click \"Open Connection\"|`ftp archive.stsci.edu`|in the address bar, type:|search for your datasets, either by narrowing down with the filters described above, or **much more quickly**:|\n",
-    "|Set Server = `archive.stsci.edu`, select \"Anonymous login\"|enter username (**anonymous**) and password (**email address**)|ftp://your_email_address@archive.stsci.edu/stage/< your_directory_name \\> |search for the Observation IDs you previously found querying the \"MAST Observations by Observation ID\" at the top left|\n",
-    "|Click \"Connect\"|`cd /stage/<username>/<usernamennnnn>`|i.e. `ftp://anonymous@archive.stsci.edu:/stage/anonymous/<anonymousnnnnn>`|select the products you would like to download and click the button at the top right \"Add data products to Downloads Basket\"|\n",
-    "|Navigate to `stage/anonymous/<anonymousnnnnn>`|`prompt`|allow to open folder and sign in with anonymous and email address|click \"My Download Basket\" (upper left)|\n",
-    "|Select the files you wish to download|`binary`||select the data and data filters you want to download|\n",
-    "|Right-click and select \"Download\" or \"Download To\"|`mget *`||click \"Download selected items\" (upper right); Note that the \"Batch Retrieval\" button will stage the data as the previous HST Search interface did.|\n",
-    "||`quit`||select your preferred compression and click \"Download\"|\n",
-    "||||make sure to allow the pop-up window, which will begin the download|\n"
+    "then this number is **42822**\n",
+    "\n",
+    "Your browser will attempt to redirect to the CyberDuck application. Allow it to \"Open CyberDuck.app\", and CyberDuck should open a finder window displaying your files. Select whichever files you want to download by highlighting them (command-click or control-click) then right click one of the highlighted files, and select \"Download To\". This will bring up a file browser allowing you to save the selected files to wherever you wish on your local computer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=download_ftps_funcD></a>\n",
+    "#### Downloading the staged data with `ftps`\n",
+    "To download anonymously staged data programmatically with ftps, you may run the `download_anonymous_staged_data` function as shown here:\n",
+    "\n",
+    "```python\n",
+    "download_anonymous_staged_data(email_used=\"my_email@stsci.edu\", directory_number=80552, outdir=\"./here_is_where_I_want_the_data\")\n",
+    "```\n",
+    "\n",
+    "Which results in:\n",
+    "```\n",
+    "Downloading lcxv13050_x1dsum1.fits\n",
+    "  Done\n",
+    "...\n",
+    "...\n",
+    "Downloading lcxv13gxq_flt_b.fits\n",
+    "  Done\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ftplib\n",
+    "def download_anonymous_staged_data(email_used, directory_number, outdir = \"./data/ftps_download/\", verbose=True):\n",
+    "    \"\"\"\n",
+    "    A direct implementation of the MAST FTP Service webpage's ftplib example code.\n",
+    "    Downloads anonymously staged data from the MAST servers via ftps.\n",
+    "    Inputs:\n",
+    "    email_used (str): the email address used to stage the data\n",
+    "    directory_number (str or int): The number at the end of the anonymous filepath. i.e. if the email you received includes:\n",
+    "      \"The data can be found in the directory...  /stage/anonymous/anonymous42822\", \n",
+    "      then this number is 42822\n",
+    "    outdir (str): Path to where the file will download locally.\n",
+    "    verbose (bool): If True, prints name of each file downloaded.\n",
+    "    \"\"\"\n",
+    "    ftps = ftplib.FTP_TLS('archive.stsci.edu') # Set up connection\n",
+    "    ftps.login(user=\"anonymous\", passwd=email_used) # Login with anonymous credentials\n",
+    "    ftps.prot_p() # Add protection to the connection\n",
+    "    ftps.cwd(f\"stage/anonymous/anonymous{directory_number}\")\n",
+    "    filenames = ftps.nlst()\n",
+    "    \n",
+    "    outdir = Path(outdir) # Set up the output directory as a path\n",
+    "    outdir.mkdir(exist_ok=True)\n",
+    "    \n",
+    "    for filename in filenames: # Loop through all the staged files\n",
+    "        if verbose:\n",
+    "            print(\"Downloading \" + filename)\n",
+    "        with open(outdir / filename, 'wb') as fp: # Download each file locally\n",
+    "            ftps.retrbinary('RETR {}'.format(filename), fp.write)\n",
+    "        if verbose:\n",
+    "            print(\"  Done\")"
    ]
   },
   {
@@ -265,7 +346,7 @@
     "### Fig 1.7\n",
     "<center><img src =figures/FUF_res.png width =\"900\" title=\"File Upload Search Results\"> </center>\n",
     "\n",
-    "Now, to download all of the relavent files, we can check the **mark** box for all of them, and again hit  \"Submit marked data for retrieval from STDADS\". This time, we want to retrieve **all the calibration files** associated with each dataset, so we check the following boxes:\n",
+    "Now, to download all of the relevant files, we can check the **mark** box for all of them, and again hit  \"Submit marked data for retrieval from STDADS\". This time, we want to retrieve **all the calibration files** associated with each dataset, so we check the following boxes:\n",
     "- Uncalibrated\n",
     "- Calibrated\n",
     "- Used Reference Files\n",
@@ -657,7 +738,7 @@
     "## About this Notebook\n",
     "**Author:** Nat Kerman <nkerman@stsci.edu>\n",
     "\n",
-    "**Updated On:** 2021-07-06\n",
+    "**Updated On:** 2021-10-29\n",
     "\n",
     "> *This tutorial was generated to be in compliance with the [STScI style guides](https://github.com/spacetelescope/style-guides) and would like to cite the [Jupyter guide](https://github.com/spacetelescope/style-guides/blob/master/templates/example_notebook.ipynb) in particular.*\n",
     "\n",
@@ -693,7 +774,6 @@
    "source": [
     "**We will import:**\n",
     "- numpy to handle array functions\n",
-    "- astropy.io fits for accessing FITS files\n",
     "- astropy.table Table for creating tidy tables of the data"
    ]
   },
@@ -715,7 +795,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Ex. 1 soln:\n",
+    "## Ex. 1 solution:\n",
     "dataset_id_ = 'LDLM40010'\n",
     "exptime_ = 12403.904\n",
     "print(f\"The TRAPPIST-1 COS data is in dataset {dataset_id_}, taken with an exosure time of {exptime_}\")"
@@ -729,7 +809,7 @@
    },
    "outputs": [],
    "source": [
-    "## Ex. 2 soln:\n",
+    "## Ex. 2 solution:\n",
     "query_3 = Observations.query_criteria(obs_id = 'LDLM40010',\n",
     "                                        wavelength_region=\"UV\", instrument_name=\"COS/FUV\", filters = 'G130M')\n",
     "\n",
@@ -748,7 +828,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Mostly language changes focused around downloading already staged data from the MAST archive. I did add one function, but it is a direct implementation (i.e. the only thing that has changed is I added lots of explanatory comments) of the MAST ftplib example [here](https://archive.stsci.edu/ftp.html). As such, I don't consider this a significant change. 

*Unless I hear any reason not to, I will merge these changes early next week.*