### PR TITLE
Update import for generate_astrometric_catalog

### DIFF
--- a/notebooks/DrizzlePac/using_updated_astrometry_solutions/requirements.txt
+++ b/notebooks/DrizzlePac/using_updated_astrometry_solutions/requirements.txt
@@ -1,3 +1,3 @@
 astroquery >= 0.3.9
-drizzlepac >= 3.0.2
+drizzlepac >= 3.1.3
 stwcs >= 1.5.3

--- a/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
+++ b/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
@@ -638,7 +638,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from drizzlepac.alignimages import generate_astrometric_catalog\n",
+    "from drizzlepac.align import generate_astrometric_catalog\n",
     "ast_tbl = generate_astrometric_catalog('id7307xfq_flc.fits', output=True) \n",
     "ast_tbl"
    ]


### PR DESCRIPTION
This notebook would not work with most recent (past 3 years) versions of the drizzlepac due to incorrect import of `fix-hap-astrometry` from `alignimages` instead of `align`.