### PR TITLE
Fix broken Python environment for CalCOS

### DIFF
--- a/notebooks/COS/CalCOS/CalCOS.ipynb
+++ b/notebooks/COS/CalCOS/CalCOS.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "Now we can create a new environment for running `CalCOS`; let's call it `calcos_env`, and initialize it with python version 3.10 and several packages we'll need.\n",
     "\n",
-    "``` $ conda create -n calcos_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery```\n",
+    "``` $ conda create -n calcos_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery crds```\n",
     "\n",
     "After allowing conda to proceed to installing the packages (type `y` then hit enter/return), you can see all of your environments with:\n",
     "\n",
@@ -112,9 +112,9 @@
     "\n",
     "<!-- Substitute for working astroconda - hopefully change once astroconda is updated  -->\n",
     "\n",
-    "Finally you must install the `CalCOS` package using `pip`:\n",
+    "Finally you must install the `CalCOS` and `CRDS` packages using `pip`:\n",
     "\n",
-    "``` $ pip install calcos```\n",
+    "``` $ pip install calcos crds```\n",
     "\n",
     "At this point, typing `calcos --version` into the command line and hitting enter should no longer yield the error \n",
     "\n",
@@ -136,7 +136,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"You are using:\", os.environ[\"CONDA_DEFAULT_ENV\"]) # Displays name of current conda environment"
+    "# Displays name of current conda environment\n",
+    "from os import environ\n",
+    "print(\"You are using:\", environ[\"CONDA_DEFAULT_ENV\"])"
    ]
   },
   {
@@ -300,7 +302,7 @@
    "outputs": [],
    "source": [
     "# Guery the MAST archive for data with observation id starting with lcxv1304\n",
-    "q1 = Observations.query_criteria(obs_id = 'lcxv1304*')\n",
+    "q1 = Observations.query_criteria(obs_id='lcxv1304*')\n",
     "\n",
     "# Make a list of all products we could download associates with this file\n",
     "pl = Observations.get_product_list(q1)\n",
@@ -309,11 +311,16 @@
     "asn_file_list = pl[pl[\"productSubGroupDescription\"] == 'ASN']\n",
     "\n",
     "# Filter to a list of only the products which are rawtag files\n",
-    "rawtag_list = pl[(pl[\"productSubGroupDescription\"] == 'RAWTAG_A') | (pl[\"productSubGroupDescription\"] == 'RAWTAG_B')]\n",
+    "rawtag_list = pl[\n",
+    "    (pl[\"productSubGroupDescription\"] == 'RAWTAG_A') | \n",
+    "    (pl[\"productSubGroupDescription\"] == 'RAWTAG_B')\n",
+    "]\n",
     "\n",
     "# Download the two file lists to the data directory\n",
-    "rawtag_locs = Observations.download_products(rawtag_list, download_dir=str(datadir))\n",
-    "asn_locs = Observations.download_products(asn_file_list, download_dir=str(datadir))"
+    "rawtag_locs = Observations.download_products(\n",
+    "    rawtag_list, download_dir=str(datadir))\n",
+    "asn_locs = Observations.download_products(\n",
+    "    asn_file_list, download_dir=str(datadir))"
    ]
   },
   {
@@ -353,8 +360,8 @@
     "\n",
     "Each data file has an associated set of calibration files which are needed to run the associated correction with (i.e. you need the `FLATFILE` to flat field correct the data.) These reference files must be located in the `$lref` directory to run the pipeline.\n",
     "\n",
-    "The Space Telescope Science Institute (STScI) team is regularly producing new calibration files, in an effort to keep improving data reduction. Periodically the pipeline is re-run on all COS data.\n",
-    "To determine which reference files were used most recently by STScI to calibrate your data (often, but not always the newest and best,) you can refer to your data file's \"CRDS_CTX\" keyword in its fits header (see next cell)."
+    "The Space Telescope Science Institute (STScI) team is regularly producing new calibration files in an effort to keep improving data reduction. Periodically the pipeline is re-run on all COS data.\n",
+    "To determine which reference files were used most recently by STScI to calibrate your data, you can refer to your data file's \"CRDS_CTX\" keyword in its fits header (see next cell)."
    ]
   },
   {
@@ -363,16 +370,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rawfiles = glob.glob(str(datadir/'*raw*.fits')) # find all of the raw files\n",
-    "crds_ctx = fits.getheader(rawfiles[0])['CRDS_CTX'] # Get the header of the 0th raw file, look for its CRDS context keyword\n",
-    "print(f\"The CRDS Context last run with {rawfiles[0]} was:\\t{crds_ctx}\") # print it!"
+    "# Find all of the raw files:\n",
+    "rawfiles = glob.glob(str(datadir/'*raw*.fits'))\n",
+    "# Get the header of the 0th raw file, look for its CRDS context keyword:\n",
+    "crds_ctx = fits.getheader(rawfiles[0])['CRDS_CTX']\n",
+    "# Print it:\n",
+    "print(f\"The CRDS Context last run with {rawfiles[0]} was:\\t{crds_ctx}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The value of this keyword in the header is a `.pmap` file which tells the CRDS calibration data distribution program which files to distribute. To download the reference files specified by the context, we use the tool `crds`, installed with the stsci conda channel. "
+    "The value of this keyword in the header is a `.pmap` or observatory context file which tells the CRDS calibration data distribution program which files to distribute. You can also find the newest \"operational\" context on the [HST CRDS website](https://hst-crds.stsci.edu).\n",
+    "\n",
+    "To download the reference files specified by a context file, we use the `crds` tool we installed earlier. "
    ]
   },
   {
@@ -380,18 +392,17 @@
    "metadata": {},
    "source": [
     "---\n",
+    "**If you haven't already downloaded up-to-date reference files,** (as in Section 3 of \"Setup.ipynb\",) [click to skip this cell and begin downloading the files!](#skipcellC)\n",
     "\n",
-    "<font size=\"5\"><a href=\"#skipcellC\">If you haven't downloaded the files as in Section 3 of \"Setup.ipynb\", click to skip this cell and begin downloading the files!</a></font>\n",
+    "**If you have recently downloaded COS reference files,** (i.e. if you ran Section 3 of the \"Setup\" Notebook,) you likely do not have to download more reference files. Instead, follow the instructions in this cell and then skip to Section 3.\n",
     "\n",
-    "<br>\n",
+    "If you already downloaded the files, you can simply point the pipeline to the ones you downloaded, using the `crds bestrefs` command, as shown in the following three steps. Run these steps from your command line if you already have the reference files in a local cache. *Note* also that there may be newer reference files available. To make sure you are always using the most up-to-date reference files, we advise you familiarize yourself with the newest files and documentation at the [CRDS homepage](https://hst-crds.stsci.edu).\n",
     "\n",
-    "**If you recently ran Section 3 of the \"Setup\" Notebook, you likely do not have to download more reference files.** You can instead simply point to the ones you downloaded, using the `crds bestrefs` command, as shown in the following three steps. Run these steps from your command line if and only if you already have the reference files in a local cache. *Note* also that there may be newer reference files available. To make sure you are always using the most up-to-date reference files, we advise you familiarize yourself with the newest files and documentation at the [CRDS homepage](https://hst-crds.stsci.edu).\n",
-    "\n",
-    "1. The following sets environment variable for crds to look for the reference data online:\n",
+    "1. The following sets the environment variable for crds to look for the reference data online:\n",
     "\n",
     "```$ export CRDS_SERVER_URL=https://hst-crds.stsci.edu``` \n",
     "\n",
-    "2. The following tells crds where to save the files it downloads - set this to the directory where you saved the crds_cache as in [Section 3 of our Notebook on \"Setup\"](https://spacetelescope.github.io/COS-Notebooks/Setup.html#crdsS):\n",
+    "2. The following tells crds where to save the files it downloads - set this to the directory where you saved the crds_cache, i.e. in [Section 3 of our Notebook on \"Setup\"](https://spacetelescope.github.io/COS-Notebooks/Setup.html#crdsS):\n",
     "\n",
     "```$ export CRDS_PATH=${HOME}/crds_cache```\n",
     "\n",
@@ -417,7 +428,7 @@
     "    \n",
     "<img src= ./figures/warning.png width =\"60\" title=\"CAUTION!\"> \n",
     "\n",
-    "*Note* that as of the time of this Notebook's release, the pipeline context used below was **`hst_0920.pmap`**, but this changes over time. You are running this in the future, and there is certainly a newer context you would be better off working with. Take a minute to consider this, and check the [HST Calibration Reference Data System webpage](http://hst-crds.stsci.edu/) to determine what the **current operational pmap file** is. "
+    "*Note* that as of the time of this Notebook's last update, the pipeline context used below was **`hst_0989.pmap`**, but this changes over time. You are running this in the future, and there is certainly a newer context you would be better off working with. Take a minute to consider this, and check the [HST Calibration Reference Data System webpage](http://hst-crds.stsci.edu/) to determine what the **current operational pmap file** is. "
    ]
   },
   {
@@ -426,15 +437,11 @@
    "source": [
     "Unless we are connected to the STScI network, or already have the reference files on our machine, we will need to download the reference files and tell the pipeline where to look for the flat files, bad-pixel files, etc.\n",
     "\n",
-    "<font size=\"4 \">Caution again!</font>\n",
-    "\n",
-    "<img src=figures/warning.png width =\"60\" title=\"CAUTION!\"> <img src=figures/warning.png width =\"60\" title=\"CAUTION!\"> \n",
-    "\n",
-    "The process in the following two cells can take a long time and strain network resources! If you have already downloaded *up-to-date* COS reference files, avoid doing so again.\n",
-    "\n",
-    "Instead, keep these crds files in an accessible location, and point an environment variable `lref` to this directory. For instance, if your `lref` files are on your username's home directory in a subdirectory called `crds_cache`, give Jupyter the following command then skip to [Section 2.3](#runpyC):\n",
+    "The process in the following two cells can take a long time and strain network resources. If you have already downloaded *up-to-date* COS reference files, we recommend that you avoid doing so again. Instead, keep these crds files in an accessible location, and point an environment variable `lref` to this directory. For instance, if your `lref` files are on your username's home directory in a subdirectory called `crds_cache`, give Jupyter the following command then skip to [Section 2.3](#runpyC):\n",
     "\n",
     "```%env lref /Users/<your username>/crds_cache/references/hst/cos/```\n",
+    "\n",
+    "If you have an older cache of reference files, you may also simply update your cached reference files. Please see the [CRDS Guide](https://hst-crds.stsci.edu/static/users_guide/index.html) for more information.\n",
     "\n",
     "Assuming you have not yet downloaded these files, in the next two cells, we will setup an environment of reference files, download the files, and save the output of the crds download process in a log file:"
    ]
@@ -456,7 +463,7 @@
     "# The next command depends on your context and pmap file  - it looks up the specified pmap \"context\" file,\n",
     "    # which tells it what reference files to download. It then downloads these to the CRDS_PATH directory\n",
     "# You may wish to update this pmap if there is a newer pmap file - check https://hst-crds.stsci.edu\n",
-    "!crds bestrefs --files data/*raw*.fits  --sync-references=2 --update-bestrefs --new-context 'hst_0920.pmap' "
+    "!crds bestrefs --files data/*raw*.fits  --sync-references=2 --update-bestrefs --new-context 'hst_0989.pmap' "
    ]
   },
   {
@@ -465,7 +472,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(str(outputdir/'crds_output_1.txt'), 'w') as f: # This file will contain the output of the last cell\n",
+    "# This file will contain the output of the last cell\n",
+    "with open(str(outputdir/'crds_output_1.txt'), 'w') as f:\n",
     "    f.write(cap.stdout)"
    ]
   },
@@ -482,17 +490,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crds_output_dict = {} # pair each line with its line number, start at 0\n",
-    "with open(str(outputdir/'crds_output_1.txt'), 'r') as cell_outputs: # open the file\n",
-    "    for linenum, line in enumerate(cell_outputs): # loop through lines\n",
-    "        crds_output_dict[linenum] = line[:-1] # save each line to dict\n",
-    "total_lines = len(crds_output_dict) # Get the length of the dictionary - how many lines of output\n",
+    "crds_output_dict = {}  # pair each line with its line number, start at 0\n",
+    "with open(str(outputdir/'crds_output_1.txt'), 'r') as cell_outputs:  # open the file\n",
+    "    for linenum, line in enumerate(cell_outputs):  # loop through lines\n",
+    "        crds_output_dict[linenum] = line[:-1]  # save each line to dict\n",
+    "# Get the length of the dictionary - how many lines of output\n",
+    "total_lines = len(crds_output_dict)\n",
     "\n",
-    "print(f\"Printing the first and last 5 lines of {total_lines} lines output by the previous cell:\\n\")    \n",
-    "for i in np.append(range(5), np.subtract(total_lines - 1, range(5)[::-1] )):\n",
+    "print(\n",
+    "    f\"Printing the first and last 5 lines of {total_lines} lines output by the previous cell:\\n\")\n",
+    "for i in np.append(range(5), np.subtract(total_lines - 1, range(5)[::-1])):\n",
     "    print(f\"Line {i}:   \\t\", crds_output_dict[i])\n",
     "\n",
-    "crds_output_dict.clear() # Delete the contents of the dict to avoid 'garbage' filling memory"
+    "# Delete the contents of the dict to avoid 'garbage' filling memory\n",
+    "crds_output_dict.clear()"
    ]
   },
   {
@@ -563,7 +574,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(str(outputdir/'output_calcos_1.txt'), 'w') as f: # This file now contains the output of the last cell\n",
+    "# This file now contains the output of the last cell\n",
+    "with open(str(outputdir/'output_calcos_1.txt'), 'w') as f:\n",
     "    f.write(cap.stdout)"
    ]
   },
@@ -580,17 +592,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calcos_output_dict = {} # pair each line with its line number, start at 0\n",
-    "with open(str(outputdir/'output_calcos_1.txt'), 'r') as cell_outputs: # open the file\n",
-    "    for linenum, line in enumerate(cell_outputs): # loop through lines\n",
-    "        calcos_output_dict[linenum] = line[:-1] # save each line to dict\n",
-    "total_lines = len(calcos_output_dict) # Get the length of the dictionary - how many lines of output\n",
+    "calcos_output_dict = {}  # pair each line with its line number, start at 0\n",
+    "with open(str(outputdir/'output_calcos_1.txt'), 'r') as cell_outputs:  # open the file\n",
+    "    for linenum, line in enumerate(cell_outputs):  # loop through lines\n",
+    "        calcos_output_dict[linenum] = line[:-1]  # save each line to dict\n",
+    "# Get the length of the dictionary - how many lines of output\n",
+    "total_lines = len(calcos_output_dict)\n",
     "\n",
-    "print(f\"Printing the first and last 5 lines of {total_lines} lines output by the previous cell:\\n\")    \n",
-    "for i in np.append(range(5), np.subtract(total_lines - 1, range(5)[::-1] )):\n",
+    "print(\n",
+    "    f\"Printing the first and last 5 lines of {total_lines} lines output by the previous cell:\\n\")\n",
+    "for i in np.append(range(5), np.subtract(total_lines - 1, range(5)[::-1])):\n",
     "    print(f\"Line {i}:   \\t\", calcos_output_dict[i])\n",
     "\n",
-    "calcos_output_dict.clear() # Delete the contents of the dict"
+    "calcos_output_dict.clear()  # Delete the contents of the dict"
    ]
   },
   {
@@ -660,8 +674,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "header = fits.getheader(rawfiles[0]) # Reads the header of one of the 0th rawfile\n",
-    "calibswitches = header[82:109] # The calib switches are found in lines 82 - 109 of the header\n",
+    "# Reads the header of the 0th rawfile\n",
+    "header = fits.getheader(rawfiles[0])\n",
+    "# The calib switches are found in lines 82 - 109 of the header\n",
+    "calibswitches = header[82:109]\n",
     "calibswitches"
    ]
   },
@@ -678,19 +694,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "verbose = False # Set to True to see a bit more about what is going on here\n",
+    "verbose = False  # Set to True to see a bit more about what is going on here\n",
     "\n",
-    "for i, rawfile in enumerate(rawfiles): # Find each rawfile, i is just a counter variable for the files you loop through\n",
+    "# Find each rawfile, i is just a counter variable for the files you loop through\n",
+    "for i, rawfile in enumerate(rawfiles):\n",
     "    if verbose:\n",
     "        print(rawfile)\n",
-    "    header = fits.getheader(rawfiles[i]) # Read that rawfiles header\n",
-    "    corrections = [key for key in list(header.keys()) if \"CORR\" in key] # Find all calib switches\n",
+    "    header = fits.getheader(rawfiles[i])  # Read that rawfiles header\n",
+    "    # Find all calib switches\n",
+    "    corrections = [key for key in list(header.keys()) if \"CORR\" in key]\n",
     "\n",
     "    for correction in corrections:\n",
     "        if header[correction] == 'PERFORM':\n",
     "            if verbose:\n",
-    "                print(\"switching\\t\", header[correction], \"\\t\",correction, \"\\tto OMIT\")\n",
-    "            fits.setval(rawfile, correction, value='OMIT', ext = 0) # Turn off all the calib switches"
+    "                print(\"switching\\t\", header[correction],\n",
+    "                      \"\\t\", correction, \"\\tto OMIT\")\n",
+    "            # Turn off all the calib switches\n",
+    "            fits.setval(rawfile, correction, value='OMIT', ext=0)"
    ]
   },
   {
@@ -706,7 +726,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calcos.calcos(str(datadir/asn_name), verbosity=0, outdir=str(outputdir/\"calcos_processed_2\")) \n",
+    "calcos.calcos(str(datadir/asn_name), verbosity=0,\n",
+    "              outdir=str(outputdir/\"calcos_processed_2\"))\n",
     "# Run CalCOS with all calib switches OFF; allow text output this time"
    ]
   },
@@ -727,11 +748,14 @@
    "source": [
     "verbose = False\n",
     "\n",
-    "for i, rawfile in enumerate(rawfiles): # Find each rawfile, i is just a counter variable for the files you loop through\n",
+    "# Find each rawfile, i is just a counter variable for the files you loop through\n",
+    "for i, rawfile in enumerate(rawfiles):\n",
     "    if verbose:\n",
     "        print(rawfile)\n",
-    "    fits.setval(rawfile, \"FLATCORR\", value='PERFORM', ext = 0) # Change the header's keyword FLATCORR to the value PERFORM\n",
-    "    fits.setval(rawfile, \"PHACORR\", value='PERFORM', ext = 0) # Change the header's keyword PHACORR to the value PERFORM"
+    "    # Change the header's keyword FLATCORR to the value PERFORM\n",
+    "    fits.setval(rawfile, \"FLATCORR\", value='PERFORM', ext=0)\n",
+    "    # Change the header's keyword PHACORR to the value PERFORM\n",
+    "    fits.setval(rawfile, \"PHACORR\", value='PERFORM', ext=0)"
    ]
   },
   {
@@ -741,7 +765,11 @@
    "outputs": [],
    "source": [
     "%%capture cap --no-stderr\n",
-    "calcos.calcos(str(datadir/asn_name), verbosity=2, outdir=str(outputdir/\"calcos_processed_3\") )"
+    "calcos.calcos(\n",
+    "    str(datadir/asn_name),\n",
+    "    verbosity=2,\n",
+    "    outdir=str(outputdir/\"calcos_processed_3\")\n",
+    ")"
    ]
   },
   {
@@ -750,7 +778,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(str(outputdir/'output_calcos_3.txt'), 'w') as f: # This file now contains the output of the last cell\n",
+    "# This file now contains the output of the last cell\n",
+    "with open(str(outputdir/'output_calcos_3.txt'), 'w') as f:\n",
     "    f.write(cap.stdout)"
    ]
   },
@@ -772,9 +801,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "header = fits.getheader(rawfiles[0]) # Read 0th rawfile's header\n",
-    "refFiles = header[110:138] # The 110th to 138th lines of the header are filled with these reference files\n",
-    "refFile_keys = list(refFiles[2:].keys()) # Get just the keywords i.e. \"FLATFILE\" and \"DEADTAB\"\n",
+    "header = fits.getheader(rawfiles[0])  # Read 0th rawfile's header\n",
+    "# The 110th to 138th lines of the header are filled with these reference files\n",
+    "refFiles = header[110:138]\n",
+    "# Get just the keywords i.e. \"FLATFILE\" and \"DEADTAB\"\n",
+    "refFile_keys = list(refFiles[2:].keys())\n",
     "refFiles"
    ]
   },
@@ -809,12 +840,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rawfiles_segA = glob.glob(str(datadir/'*rawtag_a*.fits')) # Find just the FUVA raw files\n",
+    "# Find just the FUVA raw files\n",
+    "rawfiles_segA = glob.glob(str(datadir/'*rawtag_a*.fits'))\n",
     "for rawfileA in rawfiles_segA:\n",
     "    print(rawfileA)\n",
-    "    with fits.open(rawfileA, mode = 'update') as hdulist:\n",
-    "        hdr0 = hdulist[0].header # Update the 0th header of that FUVA file\n",
-    "        hdr0[\"PHATAB\"] = 'lref$u1t1616ll_pha.fits' #NOTE that you need the $lref in there if you put it with your other ref files"
+    "    with fits.open(rawfileA, mode='update') as hdulist:\n",
+    "        hdr0 = hdulist[0].header  # Update the 0th header of that FUVA file\n",
+    "        # NOTE that you need the $lref in there if you put it with your other ref files\n",
+    "        hdr0[\"PHATAB\"] = 'lref$u1t1616ll_pha.fits'"
    ]
   },
   {
@@ -840,7 +873,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(str(outputdir/'output_calcos_4.txt'), 'w') as f: # This file now contains the output of the last cell\n",
+    "# This file now contains the output of the last cell\n",
+    "with open(str(outputdir/'output_calcos_4.txt'), 'w') as f:\n",
     "    f.write(cap.stdout)"
    ]
   },
@@ -869,29 +903,42 @@
    "outputs": [],
    "source": [
     "# Get the STScI calibrated x1dsum spectrum from the archive\n",
-    "Observations.download_products(Observations.get_product_list(Observations.query_criteria(obs_id = 'lcxv13040')),\n",
-    "                               mrp_only=True,  download_dir = 'data/compare/')\n",
+    "Observations.download_products(Observations.get_product_list(Observations.query_criteria(obs_id='lcxv13040')),\n",
+    "                               mrp_only=True,  download_dir='data/compare/')\n",
     "# Read in this STScI spectrum\n",
-    "output_spectrum = Table.read(str(datadir/'compare/mastDownload/HST/lcxv13040/lcxv13040_x1dsum.fits'))\n",
-    "wvln_orig, flux_orig, fluxErr_orig, dqwgt_orig = output_spectrum[1][\"WAVELENGTH\", \"FLUX\", \"ERROR\" ,\"DQ_WGT\"]\n",
-    "dqwgt_orig = np.asarray(dqwgt_orig, dtype=bool) # Convert the data quality (DQ) weight into a boolean we can use to mask the data\n",
+    "output_spectrum = Table.read(\n",
+    "    str(datadir/'compare/mastDownload/HST/lcxv13040/lcxv13040_x1dsum.fits'))\n",
+    "wvln_orig, flux_orig, fluxErr_orig, dqwgt_orig = output_spectrum[1][\n",
+    "    \"WAVELENGTH\", \"FLUX\", \"ERROR\", \"DQ_WGT\"]\n",
+    "# Convert the data quality (DQ) weight into a boolean we can use to mask the data\n",
+    "dqwgt_orig = np.asarray(dqwgt_orig, dtype=bool)\n",
     "\n",
     "# Also read in the spectrum we recently calibrated in Section 2.3\n",
-    "output_spectrum = Table.read(str(outputdir/'calcos_processed_1/lcxv13040_x1dsum.fits'))\n",
-    "new_wvln, new_flux, new_fluxErr, new_dqwgt = output_spectrum[1][\"WAVELENGTH\", \"FLUX\", \"ERROR\" ,\"DQ_WGT\"]\n",
-    "new_dqwgt = np.asarray(new_dqwgt, dtype=bool) # Convert the data quality (DQ) weight into a boolean we can use to mask the data\n",
+    "output_spectrum = Table.read(\n",
+    "    str(outputdir/'calcos_processed_1/lcxv13040_x1dsum.fits'))\n",
+    "new_wvln, new_flux, new_fluxErr, new_dqwgt = output_spectrum[1][\n",
+    "    \"WAVELENGTH\", \"FLUX\", \"ERROR\", \"DQ_WGT\"]\n",
+    "# Convert the data quality (DQ) weight into a boolean we can use to mask the data\n",
+    "new_dqwgt = np.asarray(new_dqwgt, dtype=bool)\n",
     "\n",
-    "fig, (ax0,ax1, ax2) = plt.subplots(3,1,figsize=(15,10)) # Build a 3 row x 1 column figure\n",
-    "ax0.plot(wvln_orig[dqwgt_orig], flux_orig[dqwgt_orig], linewidth = 0.5, c = 'C0', label = \"Processed by the archive\") # Plot the archive's spectrum in top section\n",
-    "ax1.plot(new_wvln[new_dqwgt], new_flux[new_dqwgt], linewidth = 0.5, c = 'C1', label = \"Just now processed by you\") # Plot your calibrated spectrum in middle section\n",
+    "fig, (ax0, ax1, ax2) = plt.subplots(\n",
+    "    3, 1, figsize=(15, 10))  # Build a 3 row x 1 column figure\n",
+    "ax0.plot(wvln_orig[dqwgt_orig], flux_orig[dqwgt_orig], linewidth=0.5, c='C0',\n",
+    "         label=\"Processed by the archive\")  # Plot the archive's spectrum in top section\n",
+    "ax1.plot(new_wvln[new_dqwgt], new_flux[new_dqwgt], linewidth=0.5, c='C1',\n",
+    "         label=\"Just now processed by you\")  # Plot your calibrated spectrum in middle section\n",
     "\n",
-    "ax2.plot(wvln_orig[dqwgt_orig], flux_orig[dqwgt_orig], linewidth = 0.5, c = 'C0', label = \"Processed by the archive\") # Plot both spectra in bottom section\n",
-    "ax2.plot(new_wvln[new_dqwgt], new_flux[new_dqwgt], linewidth = 0.5, c = 'C1', label = \"Just now processed by you\")\n",
+    "ax2.plot(wvln_orig[dqwgt_orig], flux_orig[dqwgt_orig], linewidth=0.5, c='C0',\n",
+    "         label=\"Processed by the archive\")  # Plot both spectra in bottom section\n",
+    "ax2.plot(new_wvln[new_dqwgt], new_flux[new_dqwgt],\n",
+    "         linewidth=0.5, c='C1', label=\"Just now processed by you\")\n",
     "\n",
-    "ax0.legend(loc = 'upper center',fontsize = 14);ax1.legend(loc = 'upper center',fontsize = 14); ax2.legend(loc = 'upper center',fontsize = 14)\n",
-    "ax0.set_title(\"Fig 3.1\\nComparison of processed spectra\",size = 28)\n",
+    "ax0.legend(loc='upper center', fontsize=14)\n",
+    "ax1.legend(loc='upper center', fontsize=14)\n",
+    "ax2.legend(loc='upper center', fontsize=14)\n",
+    "ax0.set_title(\"Fig 3.1\\nComparison of processed spectra\", size=28)\n",
     "plt.tight_layout()\n",
-    "plt.savefig(str(outputdir/\"fig3.1_compare_plot.png\"), dpi = 300)"
+    "plt.savefig(str(outputdir/\"fig3.1_compare_plot.png\"), dpi=300)"
    ]
   },
   {
@@ -911,7 +958,7 @@
     "## About this Notebook\n",
     "**Author:** Nat Kerman - <nkerman@stsci.edu>\n",
     "\n",
-    "**Updated On:** 2021-07-06\n",
+    "**Updated On:** 2022-03-24\n",
     "\n",
     "\n",
     "> *This tutorial was generated to be in compliance with the [STScI style guides](https://github.com/spacetelescope/style-guides) and would like to cite the [Jupyter guide](https://github.com/spacetelescope/style-guides/blob/master/templates/example_notebook.ipynb) in particular.*\n",

--- a/notebooks/COS/CalCOS/CalCOS.ipynb
+++ b/notebooks/COS/CalCOS/CalCOS.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "\\- 1.2. [Create your conda environment](#condaenvC)\n",
     "\n",
-    "\\- 1.3. [Imports and basic file directories](#impdirC)\n",
+    "\\- 1.3. [Imports and basic directories](#impdirC)\n",
     "\n",
     "\\- 1.4. [Set up a reference file directory](#lrefC)\n",
     "\n",
@@ -50,7 +50,7 @@
     "# 0. Introduction\n",
     "**The Cosmic Origins Spectrograph ([*COS*](https://www.nasa.gov/content/hubble-space-telescope-cosmic-origins-spectrograph)) is an ultraviolet spectrograph on-board the Hubble Space Telescope ([*HST*](https://www.stsci.edu/hst/about)) with capabilities in the near ultraviolet (*NUV*) and far ultraviolet (*FUV*).**\n",
     "\n",
-    "**`CalCOS`** is the data processing pipeline which converts the raw data produced by COS's detectors onboard HST into usable spectral data. It transitions the data from a list of many individual recorded photon interactions into tables of wavelength and flux at that wavelength.\n",
+    "**`CalCOS`** is the data processing pipeline which converts the raw data produced by COS's detectors onboard HST into usable spectral data. It transforms the data from a list of many individual recorded photon interactions into tables of wavelength and flux at that wavelength.\n",
     "\n",
     "**This tutorial aims to prepare you run the `CalCOS` pipeline to reduce spectral data taken with the COS instrument.** It focuses on COS data taken in `TIME-TAG` mode. \n",
     "*Note* that there is another, less commonly used mode: `ACCUM`, which should generally be used only for UV bright targets.\n",
@@ -100,7 +100,7 @@
     "\n",
     "Now we can create a new environment for running `CalCOS`; let's call it `calcos_env`, and initialize it with python version 3.10 and several packages we'll need.\n",
     "\n",
-    "``` $ conda create -n calcos_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery crds```\n",
+    "``` $ conda create -n calcos_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery```\n",
     "\n",
     "After allowing conda to proceed to installing the packages (type `y` then hit enter/return), you can see all of your environments with:\n",
     "\n",
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At this point, if you started this Jupyter Notebook in another Python environment, you should now quit that instance, run `$ conda activate calcos_env`, and reopen this Jupyter Notebook. If you're unsure whether you're already using the `calcos_env` environment, you can see the active environment with:"
+    "At this point, if you started this Jupyter Notebook in another Python environment, you should now quit that instance, run `$ conda activate calcos_env`, and reopen this Jupyter Notebook. If you're unsure whether you're already using the `calcos_env` environment, you can see the active environment with the following cell."
    ]
   },
   {
@@ -147,7 +147,7 @@
    "source": [
     "<a id=impdirC></a>\n",
     "\n",
-    "## 1.3. Imports and basic file directories\n",
+    "## 1.3. Imports and basic directories\n",
     "\n",
     "We will import the following packages:\n",
     "\n",
@@ -157,7 +157,7 @@
     "- `astropy.io` fits for accessing FITS files\n",
     "- `astropy.table Table` for creating/reading organized tables of the data\n",
     "- `matplotlib.pyplot` for plotting data\n",
-    "- `glob`, `shutil`, and `os` for searching and working with system files\n",
+    "- `glob`, `shutil`, and `os` for searching and working with system files and variables\n",
     "- `pathlib Path` for managing system paths"
    ]
   },
@@ -530,7 +530,7 @@
     "\n",
     "**Now we have all the reference files we need to  run the pipeline on our data.**\n",
     "\n",
-    "This following cells running the pipeline can take several minutes, sometimes more than **10 minutes**, so you may choose to not run the remaining cells of this Notebook on the example data. You may, instead, wish to simply look at the rendered output in the [html version of this Notebook](https://spacetelescope.github.io/COS-Notebooks/Calcos.html).\n",
+    "This following cells which run the pipeline can take a while, sometimes more than **10 minutes**, so you may choose to not run the remaining cells of this Notebook on the example data. You may, instead, wish to simply look at the rendered output in the [html version of this Notebook](https://spacetelescope.github.io/COS-Notebooks/Calcos.html).\n",
     "\n",
     "By default, the pipeline also outputs hundreds of lines of text - we will suppress the printing of this text and instead save it to a text file."
    ]
@@ -549,7 +549,7 @@
    "source": [
     "**Now, we can run the pipeline program:**\n",
     "\n",
-    "Note that generally, `CalCOS` should be run on an association (`_asn`) file (in this case: `./data/lcxv13040_asn.fits`). You *may* run `CalCOS` directly on `_rawtag` or `_corrtag` exposure files, but this will not produce an `_x1dsum` file. No matter what type of files you run `CalCOS` on, you should only specify the FUVA segment's file, i.e. the `_rawtag_a` file. If a `rawtag_b` file is in the same directory, `CalCOS` will find both segments' files.\n",
+    "Note that generally, `CalCOS` should be run on an association (`_asn`) file (in this case: `./data/lcxv13040_asn.fits`). You *may* run `CalCOS` directly on `_rawtag` or `_corrtag` exposure files, but this will not produce an `_x1dsum` file and can result in errors for data taken at certain lifetime positions. No matter what type of files you run `CalCOS` on, you should only specify the FUVA segment's file, i.e. the `_rawtag_a` file. If a `rawtag_b` file is in the same directory, `CalCOS` will find both segments' files.\n",
     "\n",
     "In this example, we also specify that `verbosity` = 2, resulting in a **very** verbose output, and we specify a directory to put all the output files in: `output/calcos_processed_1`. To avoid polluting this Notebook with more than a thousand lines of the output, we again capture the output of the next cell and save it to `output/output_calcos_1.txt` in the cell below."
    ]
@@ -890,6 +890,7 @@
    "metadata": {},
    "source": [
     "**We'll make a very quick plot to show the two spectra calibrated by STScI's pipeline and by us right now.**\n",
+    "The two should agree very well. Small differences may be expected, given that the `RANDSEED` values may be different between the two versions.\n",
     "\n",
     "Much more information on reading in and plotting COS spectra can be found in our other tutorial: [Viewing COS Data](https://spacetelescope.github.io/COS-Notebooks/ViewData.html).\n",
     "\n",
@@ -998,7 +999,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/COS/CalCOS/CalCOS.ipynb
+++ b/notebooks/COS/CalCOS/CalCOS.ipynb
@@ -17,7 +17,9 @@
     "\n",
     "\\- 1.2. [Create your conda environment](#condaenvC)\n",
     "\n",
-    "\\- 1.3. [Set up a reference file directory](#lrefC)\n",
+    "\\- 1.3. [Imports and basic file directories](#impdirC)\n",
+    "\n",
+    "\\- 1.4. [Set up a reference file directory](#lrefC)\n",
     "\n",
     "\n",
     "**2. [Gathering the data to run `CalCOS`](#gatherC)**\n",
@@ -69,17 +71,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## We will import the following packages:\n",
+    "<a id = setupC></a>\n",
+    "# 1. Setting up the environment to run `CalCOS`\n",
     "\n",
-    "- `astroquery.mast Mast and Observations` for finding and downloading data from the [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) archive\n",
-    "- `numpy` to handle array functions (version $\\ge$ 1.17)\n",
-    "- `astropy.io` fits for accessing FITS files\n",
-    "- `astropy.table Table` for creating/reading organized tables of the data\n",
-    "- `matplotlib.pyplot` for plotting data\n",
-    "- `glob`, `shutil`, and `os` for searching and working with system files\n",
-    "- `pathlib Path` for managing system paths\n",
+    "The first step to processing your data is setting up an environment from which to run `CalCOS`.\n",
+    "<a id = prereqC></a>\n",
+    "## 1.1. Prerequisites\n",
+    "This tutorial assumes some basic knowledge of the command line and was built using a unix style shell. Those using a Windows computer will likely have the best results if working within the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).\n",
     "\n",
-    "- *Later on, we will import the `calcos` package to run the COS data pipeline*"
+    "If you do not already have any distribution of the `conda` tool, see [this page](https://astroconda.readthedocs.io/en/latest/getting_started.html#getting-started-jump) for instructions, and install either [`anaconda` (more beginner friendly, \\~ 3 GB, lots of extras you likely won't use)](https://docs.anaconda.com/anaconda/install/) or [`miniconda` (\\~ 400 MB, only what you need to make environments)](https://docs.conda.io/en/latest/miniconda.html).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "<a id = condaenvC></a>\n",
+    "## 1.2. Create your conda environment\n",
+    "\n",
+    "Once you have `conda` installed, you can create an environment. \n",
+    "\n",
+    "Open up your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows.\n",
+    "\n",
+    "First, add the \"conda-forge\" channel to your computer's conda channel list. This enables conda to look in the right place to find all the packages we want to install.\n",
+    "\n",
+    "``` $ conda config --add channels conda-forge ```\n",
+    "\n",
+    "Now we can create a new environment for running `CalCOS`; let's call it `calcos_env`, and initialize it with python version 3.10 and several packages we'll need.\n",
+    "\n",
+    "``` $ conda create -n calcos_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery```\n",
+    "\n",
+    "After allowing conda to proceed to installing the packages (type `y` then hit enter/return), you can see all of your environments with:\n",
+    "\n",
+    "``` $ conda env list```\n",
+    "\n",
+    "and then switch over to your new environment with \n",
+    "\n",
+    "``` $ conda activate calcos_env ```\n",
+    "\n",
+    "<!-- Substitute for working astroconda - hopefully change once astroconda is updated  -->\n",
+    "\n",
+    "Finally you must install the `CalCOS` package using `pip`:\n",
+    "\n",
+    "``` $ pip install calcos```\n",
+    "\n",
+    "At this point, typing `calcos --version` into the command line and hitting enter should no longer yield the error \n",
+    "\n",
+    "> ```command not found: calcos``` \n",
+    "\n",
+    "but rather respond with a version number, i.e. `3.4.0`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, if you started this Jupyter Notebook in another Python environment, you should now quit that instance, run `$ conda activate calcos_env`, and reopen this Jupyter Notebook. If you're unsure whether you're already using the `calcos_env` environment, you can see the active environment with:"
    ]
   },
   {
@@ -88,8 +136,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This line makes matplotlib plots appear in the Notebook instead of possibly showing up in separate windows\n",
-    "%matplotlib inline\n",
+    "print(\"You are using:\", os.environ[\"CONDA_DEFAULT_ENV\"]) # Displays name of current conda environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=impdirC></a>\n",
+    "\n",
+    "## 1.3. Imports and basic file directories\n",
+    "\n",
+    "We will import the following packages:\n",
+    "\n",
+    "- `calcos` to run the COS data pipeline\n",
+    "- `astroquery.mast Mast and Observations` for finding and downloading data from the [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) archive\n",
+    "- `numpy` to handle array functions (version $\\ge$ 1.17)\n",
+    "- `astropy.io` fits for accessing FITS files\n",
+    "- `astropy.table Table` for creating/reading organized tables of the data\n",
+    "- `matplotlib.pyplot` for plotting data\n",
+    "- `glob`, `shutil`, and `os` for searching and working with system files\n",
+    "- `pathlib Path` for managing system paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import for: The COS Data Reduction Pipeline\n",
+    "import calcos\n",
     "\n",
     "# Import for: Manipulating arrays\n",
     "import numpy as np\n",
@@ -100,6 +177,8 @@
     "\n",
     "# Import for: Plotting\n",
     "import matplotlib.pyplot as plt\n",
+    "# This line makes matplotlib plots appear in the Notebook instead of possibly showing up in separate windows\n",
+    "%matplotlib inline\n",
     "\n",
     "# Import for: Downloading data from archive\n",
     "from astroquery.mast import Observations\n",
@@ -110,7 +189,7 @@
     "# Import for: Making environment variables\n",
     "import os, shutil\n",
     "\n",
-    "#Import for: working with system paths\n",
+    "# Import for: Working with system paths\n",
     "from pathlib import Path"
    ]
   },
@@ -118,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## We will also define a few directories in which to place our data and plots."
+    "### We will also define a few basic directories in which to place our inputs and outputs."
    ]
   },
   {
@@ -140,73 +219,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id = setupC></a>\n",
-    "# 1. Setting up the environment to run `CalCOS`\n",
-    "\n",
-    "**This section is explained fully in our Notebook on [setting up an environment to work with COS data in `Python`](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb).**\n",
-    "\n",
-    "**If you have followed that Notebook and have a conda environment set up and a cache of reference files downloaded, please [click here](#gatherC) to skip this section.**\n",
-    "\n",
-    "---\n",
-    "\n",
-    "The first step to processing your data is setting up an environment from which to run `CalCOS`.\n",
-    "<a id = prereqC></a>\n",
-    "## 1.1. Prerequisites\n",
-    "This tutorial assumes some basic knowledge of the command line and was built using a unix bash-style shell. Those using a Windows computer will likely have the best results if working within the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).\n",
-    "\n",
-    "\n",
-    "If you do not already have any distribution of the `conda` tool, see [this page](https://astroconda.readthedocs.io/en/latest/getting_started.html#getting-started-jump) for instructions, and install either [`anaconda` - more beginner friendly, \\~ 3 GB, lots of extras you likely won't use](https://docs.anaconda.com/anaconda/install/) or [`miniconda` - \\~ 400 MB, only what you need](https://docs.conda.io/en/latest/miniconda.html).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "<a id = condaenvC></a>\n",
-    "## 1.2. Create your conda environment\n",
-    "\n",
-    "Once you have `conda` installed, you can create an environment. If you already setup an `astroconda` environment in the Notebook on \"Setting up your environment\", you may skip this and merely activate the environment you created then (i.e. `conda activate <environment name>`).\n",
-    "\n",
-    "Open up your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows.\n",
-    "\n",
-    "First, add the stsci channel to your computer's conda channel list. This enables conda to look in the right place to find all the packages we want to install.\n",
-    "\n",
-    "\n",
-    "``` $ conda config --add channels http://ssb.stsci.edu/astroconda```\n",
-    "\n",
-    "Now we can create a new environment for running `CalCOS`; let's call it `calcos_env`, and initialize it with the packages in the stsci channel's list we just added.\n",
-    "\n",
-    "\n",
-    "``` $ conda create -n calcos_env stsci ```\n",
-    "\n",
-    "After allowing conda to proceed to installing the packages (type `y` then hit enter/return), you can see all of your environments with:\n",
-    "\n",
-    "``` $ conda env list```\n",
-    "\n",
-    "and then switch over to your new environment with \n",
-    "\n",
-    "``` $ conda activate calcos_env ```\n",
-    "\n",
-    "At this point, typing `calcos` into the command line and hitting enter should no longer yield the error \n",
-    "\n",
-    "> ```command not found: calcos``` \n",
-    "\n",
-    "but rather respond that:\n",
-    "\n",
-    "> ```The command-line options are:\n",
-    "  --version (print the version number and exit)\n",
-    "  -r (print the full version string and exit)\n",
-    "  ...\n",
-    "  ERROR:  An association file name or observation rootname must be specified.```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "<a id = lrefC></a>\n",
-    "## 1.3. Set up a reference file directory\n",
+    "## 1.4. Set up a reference file directory\n",
     "\n",
     "`CalCOS` needs to be able to find all your reference files, (flat field image, bad pixel table, etc.), and the best way to enable that is to create a central directory of all the calibration files you'll need. We refer to this directory  as \"lref\" by convention, and set a system variable `lref` to the location of the directory. In this section, we will create the `lref` environment variable; however, we need to populate the `lref` folder with the actual reference files. We do this in [Section 2.2](#reffileC). If you have already downloaded the set of COS reference files you need to use into an existing lref directory, you should instead set `lref` to the path to this directory. \n",
     "\n",
@@ -217,8 +231,7 @@
     "\n",
     "|Unix-style Command Line| Python | Jupyter Notebook|\n",
     "|-|-|-|\n",
-    "| export lref='./data/reference/...' | import os| %env lref ./data/reference/...|\n",
-    "||os.environ[\"lref\"] = \"./data/reference/...\" ||\n",
+    "| export lref='./data/reference/...' | os.environ[\"lref\"] = \"./data/reference/...\"| %env lref ./data/reference/...|\n",
     "\n",
     "\n",
     "Note that this system variable must be set again with every new instance of a terminal - if you frequently need to use the same `lref` directory, consider adding an export statement to your `.bash_profile` or equivalent file.\n",
@@ -516,18 +529,7 @@
    "metadata": {},
    "source": [
     "<a id = runpyC></a>\n",
-    "## 3.1. Running `CalCOS`: *From a python environment*\n",
-    "\n",
-    "First, we import the pipeline package:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import calcos"
+    "## 3.1. Running `CalCOS`: *From a python environment*"
    ]
   },
   {
@@ -935,7 +937,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -949,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The new versions of CalCOS require Python>=3.8, and the astroconda system doesn't currently support this. As such, the CalCOS Notebook needs this update to allow it to use CalCOS at all. 

The update, at least for now, can't use astroconda, so we instead set up a simple conda environment, and then pip install calcos and crds.

I've also made a few small text changes, and run a pep8 formatter on some of the code cells to meet DMD guidelines. The code's content is unchanged.