### PR TITLE
Update the way the COS Notebooks suggest that a user create conda envs

### DIFF
--- a/notebooks/COS/AsnFile/AsnFile.ipynb
+++ b/notebooks/COS/AsnFile/AsnFile.ipynb
@@ -57,7 +57,7 @@
     "- `datetime` for updating fits headers with today's date\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "If you have an existing astroconda environment, it may already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
+    "If you have an existing astroconda environment, it may or may not already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
    ]
   },
   {

--- a/notebooks/COS/AsnFile/AsnFile.ipynb
+++ b/notebooks/COS/AsnFile/AsnFile.ipynb
@@ -57,7 +57,7 @@
     "- `datetime` for updating fits headers with today's date\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "These python packages are installed standard with the the STScI conda distribution. For more information, see our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
+    "If you have an existing astroconda environment, it may already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
    ]
   },
   {

--- a/notebooks/COS/DayNight/DayNight.ipynb
+++ b/notebooks/COS/DayNight/DayNight.ipynb
@@ -54,7 +54,7 @@
     "- `astroquery.mast Mast` and `Observations` for finding and downloading data from the [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) archive\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "These python packages, including `calcos` and `costools` are installed standard with the the STScI conda distribution. For more information, see our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
+    "New versions of `CalCOS` are currently incompatible with astroconda. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
    ]
   },
   {

--- a/notebooks/COS/Extract/Extract.ipynb
+++ b/notebooks/COS/Extract/Extract.ipynb
@@ -74,7 +74,7 @@
     "- `scipy.interpolate interp1d` for interpolating datasets to the same sampling\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "These Python packages are installed standard with the the STScI conda distribution. For more information, see our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb).\n",
+    "New versions of `CalCOS` are currently incompatible with astroconda. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb).\n",
     "\n",
     "We'll also filter out two unhelpful warnings about a deprecation and dividing by zero which do not affect our data processing."
    ]

--- a/notebooks/COS/LSF/LSF.ipynb
+++ b/notebooks/COS/LSF/LSF.ipynb
@@ -72,7 +72,7 @@
     "- `tarfile` for unzipping some compressed STIS data\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "If you have an existing astroconda environment, it may already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
+    "If you have an existing astroconda environment, it may or may not already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
    ]
   },
   {

--- a/notebooks/COS/LSF/LSF.ipynb
+++ b/notebooks/COS/LSF/LSF.ipynb
@@ -72,7 +72,7 @@
     "- `tarfile` for unzipping some compressed STIS data\n",
     "- `pathlib Path` for managing system paths\n",
     "\n",
-    "These Python packages are installed standard with the the STScI conda distribution. For more information, see our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
+    "If you have an existing astroconda environment, it may already have the necessary packages to run this Notebook. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb)."
    ]
   },
   {

--- a/notebooks/COS/Setup/Setup.ipynb
+++ b/notebooks/COS/Setup/Setup.ipynb
@@ -61,7 +61,7 @@
     "# 1. Setting up a `conda` environment for working with COS data\n",
     "<a id = installcondaS></a>\n",
     "## 1.1. Installing `conda`\n",
-    "If you are viewing this Notebook's `.ipynb` file, (rather than the rendered `.html` file,) you may already have a working `conda` tool. To check whether you have `conda` installed, open a terminal window and type `conda -V`, or run the next cell. If your `conda` is installed and working, the terminal or cell will return the version of conda."
+    "You may already have a working `conda` tool. To check whether you have `conda` installed, open a terminal window and type `conda -V`, or run the next cell. If your `conda` is installed and working, the terminal or cell will return the version of conda."
    ]
   },
   {
@@ -94,9 +94,9 @@
     "\n",
     "`conda` allows for separate sets of packages to be installed on the same system in different environments, and for these environments to be shared so that other users can install the packages you used to get your code running. These packages are vital parts of your programming toolkit, and allow you to avoid \"reinventing the wheel\" by leveraging other peoples' code. Thus, packages should be treated as any resource created by other person, and cited to avoid plagiarizing. \n",
     "\n",
-    "One package which is often necessary for working with COS data is `calcos`, which runs the CalCOS data pipeline. However, this package will not, by default, be installed on your computer. We will install CalCOS, as well as all the other packages you will need to run any of these COS Notebooks.\n",
+    "One package which is often necessary for working with COS data is `calcos`, which runs the [CalCOS data pipeline](https://hst-docs.stsci.edu/cosdhb/chapter-3-cos-calibration/3-2-pipeline-processing-overview). However, this package will not, by default, be installed on your computer. We will install CalCOS, as well as all the packages you will need to run any of these COS Notebooks.\n",
     "\n",
-    "Open up your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows. We'll begin by adding the `conda-forge` channel to `conda`'s channel list. This enables `conda` to look in the right place to find all the packages we want to install.\n",
+    "Open your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows. We'll begin by adding the `conda-forge` channel to `conda`'s channel list. This enables `conda` to look in the right place to find all the packages we want to install.\n",
     "\n",
     "``` $ conda config --add channels conda-forge```"
    ]
@@ -107,7 +107,7 @@
    "source": [
     "Now we can create our new environment. We'll call it `cos_analysis_env`, and initialize it with python version 3.10 and several packages we'll need.\n",
     "\n",
-    "<!-- Substitute for working astroconda - hopefully change once astroconda is updated  -->\n",
+    "<!-- Substitute for working astroconda - This will revert to using astroconda once the astroconda software is updated  -->\n",
     "\n",
     "``` $ conda create -n cos_analysis_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery```\n",
     "\n",
@@ -192,7 +192,7 @@
     "* **Time-dependent sensitivity (TDS) tables** to correct for [COS' long-term loss of sensitivity](https://www.stsci.edu/hst/instrumentation/cos/performance/sensitivity)\n",
     "* **Many more** - see [COS Data Handbook Section 3.4](https://hst-docs.stsci.edu/cosdhb/chapter-3-cos-calibration/3-4-descriptions-of-spectroscopic-calibration-steps)\n",
     "\n",
-    "These reference files are regularly updated by the COS team to provide the best possible calibration. The current and prior files are all hosted by the [HST Calibration Reference Data System (CRDS)](https://hst-crds.stsci.edu). To get the most up-to-date COS reference files, you can use the `crds` command line tool provided which we installed in [Section 1](#setupEnvS) of this Notebook. \n",
+    "These reference files are regularly updated by the COS team to provide the best possible calibration. The current and prior files are all hosted by the [HST Calibration Reference Data System (CRDS)](https://hst-crds.stsci.edu). To get the most up-to-date COS reference files, you can use the `crds` command line tool which we installed in [Section 1](#setupEnvS) of this Notebook. \n",
     "\n",
     "**Because some of these files are quite large, it is *highly recommended* you create a cache on your computer of all the COS files, which you may then update as necessary. We'll explain how to set up that cache below.**\n",
     "\n",

--- a/notebooks/COS/Setup/Setup.ipynb
+++ b/notebooks/COS/Setup/Setup.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "#### Other notes:\n",
     "\n",
-    "- It is possible to use another package manager, i.e. `pip`, to install necessary packages, however at present, `conda` is recommended, and the best documented package manager for these Notebooks."
+    "- It is sometimes preferable to use another package manager - `pip` - to install necessary packages, however `conda` can be used to create Python environments as well as install packages. You may see both `pip` and `conda` used in these Notebooks."
    ]
   },
   {
@@ -61,7 +61,7 @@
     "# 1. Setting up a `conda` environment for working with COS data\n",
     "<a id = installcondaS></a>\n",
     "## 1.1. Installing `conda`\n",
-    "If you are viewing this Notebook's `.ipynb` file, (rather than the rendered `.html` file,) you may already have a working conda tool. To check whether you have conda installed, open a terminal window and type `conda -V`, or run the next cell. If your conda is installed and working, the terminal will return the version."
+    "If you are viewing this Notebook's `.ipynb` file, (rather than the rendered `.html` file,) you may already have a working `conda` tool. To check whether you have `conda` installed, open a terminal window and type `conda -V`, or run the next cell. If your `conda` is installed and working, the terminal or cell will return the version of conda."
    ]
   },
   {
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda -V"
+    "! conda -V"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "|Conda Distribution (with link to download)|Short Description|Size|\n",
     "|-|-|-|\n",
     "|[`anaconda` Distribution](https://docs.anaconda.com/anaconda/install/) | More beginner friendly, with lots of extras you likely won't use| \\~ 3 GB|\n",
-    "|[`miniconda` Distribution](https://docs.conda.io/en/latest/miniconda.html)| Bare-bones conda distribution, which allows you to download only what you need|\\~ 400 MB|"
+    "|[`miniconda` Distribution](https://docs.conda.io/en/latest/miniconda.html)| Bare-bones `conda` distribution, which allows you to download only what you need|\\~ 400 MB|"
    ]
   },
   {
@@ -92,65 +92,69 @@
     "<a id = createenvS></a>\n",
     "## 1.2. Creating a `conda` environment\n",
     "\n",
-    "`conda` allows for separate sets of packages to be installed on the same system in different environments, and for these environments to be shared so that other users can install the packages you used to get your code running. These packages are vital parts of your programming toolkit, and allow you to avoid \"reinventing the wheel\" by leveraging other peoples' code. Thus, packages should be treated as any resource created by other person, and cited to avoid plagiarizing. One package critical to working with COS data is `calcos`, which runs the CalCOS data pipeline. However, this package will not, by default, be installed on your computer. We need to install it.\n",
+    "`conda` allows for separate sets of packages to be installed on the same system in different environments, and for these environments to be shared so that other users can install the packages you used to get your code running. These packages are vital parts of your programming toolkit, and allow you to avoid \"reinventing the wheel\" by leveraging other peoples' code. Thus, packages should be treated as any resource created by other person, and cited to avoid plagiarizing. \n",
     "\n",
-    "We will be downloading a conda environment set up by the Space Telescope Science Institute (*STScI*), which contains all the packages, including `calcos`, that we need to run the tutorials, as well as most of what one is likely to need for astronomical data processing.\n",
+    "One package which is often necessary for working with COS data is `calcos`, which runs the CalCOS data pipeline. However, this package will not, by default, be installed on your computer. We will install CalCOS, as well as all the other packages you will need to run any of these COS Notebooks.\n",
     "\n",
-    "Open up your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows.\n",
+    "Open up your terminal app, likely `Terminal` or `iTerm` on a Mac or `Windows Terminal` or `Powershell` on Windows. We'll begin by adding the `conda-forge` channel to `conda`'s channel list. This enables `conda` to look in the right place to find all the packages we want to install.\n",
     "\n",
-    "First, add the stsci channel to your computer's conda channel list. This enables conda to look in the right place to find all the packages we want to install.\n",
-    "\n",
-    "``` $ conda config --add channels http://ssb.stsci.edu/astroconda```"
+    "``` $ conda config --add channels conda-forge```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can create our new environment; we'll call it `astroconda_hst`, and initialize it with the packages in the stsci channel's list we just added, as well as the jupyter Notebook and jupyter lab packages necessary for running these Notebooks.\n",
+    "Now we can create our new environment. We'll call it `cos_analysis_env`, and initialize it with python version 3.10 and several packages we'll need.\n",
     "\n",
+    "<!-- Substitute for working astroconda - hopefully change once astroconda is updated  -->\n",
     "\n",
-    "``` $ conda create -n astroconda_hst stsci-hst python=3.7 notebook jupyterlab ```\n",
+    "``` $ conda create -n cos_analysis_env python=3.10 notebook jupyterlab numpy astropy matplotlib astroquery```\n",
     "\n",
-    "After allowing conda to proceed to installing the packages (when prompted, type `y` then hit enter/return), `conda` will need a few minutes, depending on your internet speed, to install the packages.\n",
-    "\n",
-    "After this installation finishes, you can see all of your environments with:\n",
+    "Allow `conda` to install the packages (when prompted, type `y` then enter/return). Then, `conda` will need a few minutes, depending on your internet speed, to install the packages. After this installation finishes, you can see all of your environments with:\n",
     "\n",
     "``` $ conda env list```\n",
     "\n",
-    "and then switch over to your new environment with \n",
+    "Now, activate your new environment with:\n",
     "\n",
-    "``` $ conda activate astroconda_hst ```\n",
+    "``` $ conda activate cos_analysis_env ```\n",
     "\n",
-    "*Note* that you will need to activate your environment every time you open a new terminal or shell. \n",
+    "*Note* that you will need to activate your environment every time you open a new terminal or shell. You can do this automatically by appending `conda activate cos_analysis_env` to the end of your `.bashrc` or equivalent file. You must activate your desired `conda` environment *before* starting a Jupyter Notebook kernel in that terminal.\n",
     "\n",
-    "### Testing our installation\n",
-    "We can test our installation by importing a package or using a tool which should be installed with STScI's astroconda distribution.\n",
-    "At this point, typing `calcos` into the command line and hitting enter should no longer yield the error \n",
+    "Finally, install the `CalCOS`, `COSTools`, and `CRDS` packages using `pip`:\n",
     "\n",
-    "> ```command not found: calcos``` \n",
-    "\n",
-    "but rather respond that:\n",
-    "\n",
-    "> ```The command-line options are:\n",
-    "  --version (print the version number and exit)\n",
-    "  -r (print the full version string and exit)\n",
-    "  ...\n",
-    "  ERROR:  An association file name or observation rootname must be specified.```"
+    "``` $ pip install calcos costools crds```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Adding other packages\n",
-    "We can add any other packages not included in astrocoda with this command:\n",
+    "### Testing our installation\n",
+    "We can test our installation by importing some of these packages. From the command line, try running:\n",
     "\n",
-    "```$ conda install <first package name> <second package name> ... <last package name>```\n",
+    "``` $ python --version; python -c \"import  numpy, calcos; print('Imports succesful')\"```\n",
+    "\n",
+    "This should return:\n",
+    "\n",
+    "```\n",
+    "Python 3.10.4    #(or a similar version number)\n",
+    "Imports successful\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installing other packages\n",
+    "We can add any other packages we need with this command:\n",
+    "\n",
+    "```$ pip install <first package name> <second package name> ... <last package name>```\n",
     "\n",
     "Now, go ahead and install the [`specutils` package](https://specutils.readthedocs.io/en/stable/), which is briefly discussed in the ViewData.ipynb Notebook, using the following command:\n",
     "\n",
-    "```$ conda install specutils```"
+    "```$ pip install specutils```"
    ]
   },
   {
@@ -188,7 +192,7 @@
     "* **Time-dependent sensitivity (TDS) tables** to correct for [COS' long-term loss of sensitivity](https://www.stsci.edu/hst/instrumentation/cos/performance/sensitivity)\n",
     "* **Many more** - see [COS Data Handbook Section 3.4](https://hst-docs.stsci.edu/cosdhb/chapter-3-cos-calibration/3-4-descriptions-of-spectroscopic-calibration-steps)\n",
     "\n",
-    "These reference files are regularly updated by the COS team to provide the best possible calibration. The current and prior files are all hosted by the [HST Calibration Reference Data System (CRDS)](https://hst-crds.stsci.edu). To get the most up-to-date COS reference files, you can use the `crds` command line tool provided with the `astroconda` distribution you set up in [Section 1](#setupEnvS) of this Notebook. \n",
+    "These reference files are regularly updated by the COS team to provide the best possible calibration. The current and prior files are all hosted by the [HST Calibration Reference Data System (CRDS)](https://hst-crds.stsci.edu). To get the most up-to-date COS reference files, you can use the `crds` command line tool provided which we installed in [Section 1](#setupEnvS) of this Notebook. \n",
     "\n",
     "**Because some of these files are quite large, it is *highly recommended* you create a cache on your computer of all the COS files, which you may then update as necessary. We'll explain how to set up that cache below.**\n",
     "\n",
@@ -238,11 +242,9 @@
    "source": [
     "### The CRDS Command line tool\n",
     "\n",
-    "Now we can use the CRDS command line tool to download all the files in this context\n",
+    "Now we can use the CRDS command line tool to download all the files in this context. Remember to first activate the `conda` environment you created in Section 1, or you may not have the necessary `crds` package installed.\n",
     "\n",
-    "From your command line, we must now set several environment variables.\n",
-    "\n",
-    "First, tell the crds command line tool where to go looking for the reference files online:\n",
+    "From your command line, we must now set several environment variables. First, tell the crds command line tool where to go looking for the reference files online:\n",
     "\n",
     "```$ export CRDS_SERVER_URL=https://hst-crds.stsci.edu```\n",
     "\n",
@@ -304,7 +306,7 @@
     "## About this Notebook\n",
     "**Author:** Nat Kerman <nkerman@stsci.edu>\n",
     "\n",
-    "**Updated On:** 2021-07-08\n",
+    "**Updated On:** 2022-04-26\n",
     "\n",
     "\n",
     "> *This tutorial was generated to be in compliance with the [STScI style guides](https://github.com/spacetelescope/style-guides) and would like to cite the [Jupyter guide](https://github.com/spacetelescope/style-guides/blob/master/templates/example_notebook.ipynb) in particular.*\n",
@@ -331,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/COS/SplitTag/SplitTag.ipynb
+++ b/notebooks/COS/SplitTag/SplitTag.ipynb
@@ -55,7 +55,7 @@
     "- `astroquery.mast Mast` and `Observations` for finding and downloading data from the [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) archive\n",
     "- `warnings` and `astropy.units Warnings` for suppressing a warning that is not helpful later on.\n",
     "\n",
-    "These python packages, including `calcos` and `costools` are installed standard with the the STScI conda distribution. For more information, see our notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb). Your version of `costools` may display a message on input about `TEAL` support (described [here](#tealST)), but you may ignore this as it is largely irrelevant to our discussion."
+    "New versions of `CalCOS` are currently incompatible with astroconda. To create a Python environment capable of running all the data analyses in these COS Notebooks, please see Section 1 of our Notebook tutorial on [setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb). Your version of `costools` may display a message on input about `TEAL` support (described [here](#tealST)), but you may ignore this as it is largely irrelevant to our discussion."
    ]
   },
   {
@@ -430,7 +430,7 @@
     "<a id=tealST></a>\n",
     "While not implemented within the Jupyter Notebook framework, you can also run `splittag` from a TEAL graphical user interface (GUI) on a local computer (see Fig 2.2).\n",
     "\n",
-    "To generate the GUI, open an astroconda python distribution (as described in the [Setup Notebook](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb), and run the following lines of python code:\n",
+    "To generate the GUI, open Python (specifically a Python environment with `costools` installed) on the command line and run the following lines of code:\n",
     "\n",
     "```python\n",
     "import costools\n",
@@ -948,12 +948,12 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "7830028ce50bb5956210a3e3b4fcc42bd59ed86f76b059f664ccd2fd10bc59ff"
+   "hash": "e5784b3e3be4ffa319eb7c9e4ac489bbbf191ad109372c471204ed1d5c08c61e"
   },
   "kernelspec": {
    "display_name": "Python [conda env:astroconda_plhst_20210505_2] *",
    "language": "python",
-   "name": "conda-env-astroconda_plhst_20210505_2-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -965,7 +965,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.5"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/notebooks/COS/ViewData/ViewData.ipynb
+++ b/notebooks/COS/ViewData/ViewData.ipynb
@@ -89,7 +89,7 @@
     "- `matplotlib.pyplot` for plotting data\n",
     "- `astroquery.mast Mast and Observations` for finding and downloading data from the [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) archive\n",
     "\n",
-    "*Later on, we will import some functions from a local file*, `cos_functions.py`, which is installed as part of the same GitHub repository as this Notebook. If you do not see this `Python` file in this directory, you can find it [here](https://github.com/spacetelescope/notebooks/tree/master/notebooks/COS/ViewData/)."
+    "*Later on, we will import some functions from a local file*, `cos_functions.py`, which is installed as part of the same GitHub repository as this Notebook. If you do not see this `Python` file in this directory, you can find it [here](https://github.com/spacetelescope/notebooks/tree/master/notebooks/COS/ViewData/). `cos_functions.py` must be installed next to this Notebook (`ViewData.ipynb`)."
    ]
   },
   {
@@ -687,7 +687,7 @@
     "### 2.1.4. Reading and plotting the data with `specutils` (*OPTIONAL*)\n",
     "<font size=\"5\"> <em>Note, this section is entirely optional, and simply meant to give you more options for how to plot a spectrum.</em></font>\n",
     "\n",
-    "An alternative way to read in and work with spectral data is with the [`specutils` package](https://specutils.readthedocs.io/en/stable/), which contains *quite a bit of functionality* for working with spectra. It also can make dealing with units easier, as it generally works well with astropy units and other modules. Make sure that your package is up to date (version $\\ge$ 1.1). `specutils` is installed as part of the astroconda distribution, described in our Notebook on setting up an environment.\n",
+    "An alternative way to read in and work with spectral data is with the [`specutils` package](https://specutils.readthedocs.io/en/stable/), which contains *quite a bit of functionality* for working with spectra. It also can make dealing with units easier, as it generally works well with astropy units and other modules. Make sure that your package is up to date (version $\\ge$ 1.1). We describe installing `specutils` in our [Notebook on setting up an environment](https://github.com/spacetelescope/notebooks/blob/master/notebooks/COS/Setup/Setup.ipynb).\n",
     "\n",
     "`specutils` treats spectra as special python objects rather than lists, and reads in the entire spectrum over both segments. \n",
     "\n",


### PR DESCRIPTION
Previously, the COS Notebooks guided a user through creating a Python environment using the STScI astroconda method. However, Astroconda is currently not compatible with Python > 3.7 and CalCOS requires Python > 3.7. This incompatibility means that we must provide an alternate way for our users to set up an environment. This was previously changed in only the `CalCOS.ipynb` Notebook; however, this PR changes the guide to setting up an environment in the central `Setup.ipynb` Notebook. This is important because half of the COS Notebooks rely on CalCOS and thus are incompatible with astroconda. 

Since relatively few packages are needed for these Notebooks (10 packages), the COS team opted for installing all of them directly on the CLI, rather than burying them in a Requirements file (which does exist). This will encourage users to better understand what is going on, and why. When astroconda or a suitable replacement which is compatible with CalCOS is made public, these Notebooks should be reverted/updated to rely on that method.

The changes are restricted to Markdown, rather than code sections. As such it is eligible for a self-merge. 