### PR TITLE
Small correction to sweeps_hscv3p1_api.ipynb

### DIFF
--- a/notebooks/MAST/HSC/SWEEPS_HSCV3P1_API/sweeps_hscv3p1_api.ipynb
+++ b/notebooks/MAST/HSC/SWEEPS_HSCV3P1_API/sweeps_hscv3p1_api.ipynb
@@ -789,8 +789,7 @@
     "\n",
     "print(f\"Plotting {len(wpmh)} objects\")\n",
     "for o in tab[\"ObjID\"][wpmh]:\n",
-    "    positions(o)\n",
-    "    positions1(o)"
+    "    positions(o)"
    ]
   },
   {


### PR DESCRIPTION
- positions1 was a remnant from testing. Needs to be deleted, as there is no positions1 function