### PR TITLE
Add deprecation banners

### DIFF
--- a/notebooks/DrizzlePac/Initialization/Initialization.ipynb
+++ b/notebooks/DrizzlePac/Initialization/Initialization.ipynb
@@ -6,7 +6,13 @@
    "source": [
     "# DrizzlePac Initialization\n",
     "\n",
-    "<br>This Jupyter notebook discusses the steps necessary to set up your computing environment to use DrizzlePac. This is the first step before using any of the other DrizzlePac tutorials. The code cells in this notebook can be used to partially confirm that your environment is properly configured for DrizzlePac before proceeding to the other tutorials.\n",
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>\n",
+    "\n",
+    "This Jupyter notebook discusses the steps necessary to set up your computing environment to use DrizzlePac. This is the first step before using any of the other DrizzlePac tutorials. The code cells in this notebook can be used to partially confirm that your environment is properly configured for DrizzlePac before proceeding to the other tutorials.\n",
     "\n"
    ]
   },
@@ -315,7 +321,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -329,9 +335,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
+++ b/notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -927,7 +931,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -941,9 +945,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
+++ b/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -620,7 +624,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -634,9 +638,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
+++ b/notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -478,7 +482,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -492,9 +496,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -12,7 +12,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initializtion.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, 'DrizzlePac' or 'Astroquery'.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -566,9 +570,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
+++ b/notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -72,9 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Retrieve the observation information.\n",
@@ -430,7 +432,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -444,9 +446,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initializtion.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -228,7 +232,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "## 3. Manual masking of satellites and other anomalies\n",
@@ -343,7 +350,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -357,9 +364,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.ipynb
+++ b/notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -189,9 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with fits.open('f160w_noopt_drz.fits') as hdu:\n",
@@ -400,7 +402,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "## 6. Final thoughts\n",
@@ -421,7 +426,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -435,9 +440,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/sky_matching/sky_matching.ipynb
+++ b/notebooks/DrizzlePac/sky_matching/sky_matching.ipynb
@@ -11,7 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initialization.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>"
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -80,9 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Retrieve the observation information.\n",
@@ -533,7 +535,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -547,9 +549,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
+++ b/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
@@ -11,9 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-danger\">Note: The notebook in this repository 'Initializtion.ipynb' goes over many of the basic concepts such as the setup of the environment/package installation and should be read first if you are new to HST images, DrizzlePac, or Astroquery.</div>\n",
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
     "\n",
-    "<a id='top'></a>"
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
    ]
   },
   {
@@ -628,7 +630,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -642,9 +644,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
+++ b/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-danger\"><b>Warning! This notebook and repository are now deprecated. Please visit the HST Notebook Repository for supported notebooks:</b></div>\n",
+    "\n",
+    "<b>HST Notebook Repository Page: [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/)</b>\n",
+    "\n",
+    "<b>Notebook Repository on Github: [https://github.com/spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)</b>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "As part of an effort to improve the absolute astrometry of HST images, STScI has created multiple new astrometric solutions for ACS and WFC3 images.  These solutions are contained in the World Coordinate System (WCS) of the images, as well as headerlet extesions.  This notebook provides an example workflow showing how to use/change to a different solution."
    ]
   },
@@ -682,9 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(10,5))\n",
@@ -750,7 +759,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -764,9 +773,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This request adds a deprecation banner to each DrizzlePac notebook in the now deprecated "notebooks" repository. This has been implemented as an immediate solution for users locating the wrong repository until the repository is properly decommissioned.